### PR TITLE
Fix segfault with protocol fallback code

### DIFF
--- a/src/src/main.cc
+++ b/src/src/main.cc
@@ -597,11 +597,11 @@ tproject_set_args(int argc, char **argv)
 
             /* backwards compatibility, if the "host" equals any of the reserved words below we default to the
              * currently signed-in community host instead and backset the pointer */
-            if (strcmp(_community_host, "play") == 0 || 
-                strcmp(_community_host, "sandbox") == 0 || 
+            if (strcmp(_community_host, "play") == 0 ||
+                strcmp(_community_host, "sandbox") == 0 ||
                 strcmp(_community_host, "edit") == 0) {
                 s -= strlen(_community_host) + 1;
-                strcpy(_community_host, P.community_host);
+                _community_host[0] = '\0';
             }
 
             if (strncmp(s, "play/", 5) == 0) {


### PR DESCRIPTION
For whatever reason, copying the regular community host to `_community_host` causes the game to segfault trying to play levels from principia-web which currently makes use of the fallback code. This fixes it by instead emptying the variable which ends up doing the same thing without a segfault.