### PR TITLE
Fix Android webview by changing initial url to HTTPS

### DIFF
--- a/src/src/menu_main.cc
+++ b/src/src/menu_main.cc
@@ -56,7 +56,7 @@ menu_main::widget_clicked(principia_wdg *w, uint8_t button_id, int pid)
                 ui::open_url(0);
 #else
                 char tmp[512];
-                snprintf(tmp, 511, "http://%s/", P.community_host);
+                snprintf(tmp, 511, "https://%s/", P.community_host);
                 ui::open_url(tmp);
 #endif
             }


### PR DESCRIPTION
As noted in #42, the community site webview currently does not load on Android due to it being accessed over HTTP, which appears to be completely verboten on modern Android at all. (ERR_CLEARTEXT_NOT_PERMITTED)