### PR TITLE
Add missing SDL dependencies for Debian-based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For making Windows release builds you would run the `make_release.sh` script, wh
 
 Install dependencies. For Debian-based distros:
 
-	$ sudo apt-get install automake libgtk2.0-dev libgl-dev libxss-dev libxxf86vm-dev libasound2-dev libudev-dev valgrind libcurl4-openssl-dev libpng-dev libjpeg-dev libfreetype6-dev
+	$ sudo apt-get install automake libgtk2.0-dev libgl-dev libxss-dev libxxf86vm-dev libasound2-dev libudev-dev valgrind libcurl4-openssl-dev libpng-dev libjpeg-dev libfreetype6-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev libsdl2-gfx-dev
 
 For Arch-based distros:
 


### PR DESCRIPTION
Tested on:
 - [x] Ubuntu 20.04
 - [x] Ubuntu 22.04
 - [x] Ubuntu 22.10
 - [x] Debian bullseye (11)
 - [x] Debian buster (10)

Fixes #54 