### PR TITLE
Fix freezes on Linux

### DIFF
--- a/build-linux/go
+++ b/build-linux/go
@@ -23,8 +23,10 @@ DEBUGFLAGS_CC="$DEBUG_SHARED  $EXTRA_DEBUGFLAGS $EXTRA_DEBUGFLAGS_CC"
 DEBUGFLAGS_CXX="$DEBUG_SHARED $EXTRA_DEBUGFLAGS $EXTRA_DEBUGFLAGS_CXX"
 DEBUGFLAGS_LD="-rdynamic $EXTRA_DEBUGFLAGS_LD"
 
-RELEASEFLAGS_CC="-Os -ffast-math -DNDEBUG=1 -fomit-frame-pointer -fvisibility=hidden -fdata-sections -ffunction-sections $EXTRA_RELEASEFLAGS_CC"
-RELEASEFLAGS_CXX="$RELEASEFLAGS_CC -fvisibility-inlines-hidden -fno-rtti $EXTRA_RELEASEFLAGS_CXX"
+RELEASE_SHARED="-ffast-math -DNDEBUG=1 -s -fomit-frame-pointer -fvisibility=hidden -fdata-sections -ffunction-sections"
+
+RELEASEFLAGS_CC="$RELEASE_SHARED $EXTRA_RELEASEFLAGS_CC"
+RELEASEFLAGS_CXX="$RELEASE_SHARED -O2 -fvisibility-inlines-hidden -fno-rtti $EXTRA_RELEASEFLAGS_CXX"
 RELEASEFLAGS_LD="-Wl,-O,-s,--gc-sections $EXTRA_RELEASEFLAGS_LD"
 
 if [ "$CC" = "gcc" ]; then


### PR DESCRIPTION
Fixes #43. Fixes freezes that occur on the release version of Linux Principia related to chunk intersections. Doesn't really fix the underlying root cause which seems to be some kind of breakage caused by compiler optimisations but this is a band-aid fix that slightly reduces the optimisation level of release versions while increasing the stability.