### PR TITLE
Added dependencies for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ For Arch-based distros:
 
 	$ sudo pacman -S gtk2 curl freetype libpng libjpeg sdl2 sdl2_gfx sdl2_image-devel sdl2_mixer sdl2_ttf
 
-For Redhat-based distros (Fedora):
-
+For Fedora:
+	$ sudo dnf groupinstall "Development Tools"
 	$ sudo dnf install automake freetype-devel libpng-devel libjpeg-turbo-devel gtk2-devel ncurses-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel
 
 For NixOS, Follow the instructions [here](./nix/README.md).

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ Install dependencies. For Debian-based distros:
 
 For Arch-based distros:
 
-	$ sudo pacman -S gtk2 curl freetype libpng libjpeg sdl2 sdl2_gfx sdl2_image sdl2_mixer sdl2_ttf
+	$ sudo pacman -S gtk2 curl freetype libpng libjpeg sdl2 sdl2_gfx sdl2_image-devel sdl2_mixer sdl2_ttf
+
+For Redhat-based distros (Fedora):
+
+	$ sudo dnf install automake freetype-devel libpng-devel libjpeg-turbo-devel gtk2-devel ncurses-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel
 
 For NixOS, Follow the instructions [here](./nix/README.md).
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For Arch-based distros:
 
 For Fedora:
 	$ sudo dnf groupinstall "Development Tools"
-	$ sudo dnf install automake freetype-devel libpng-devel libjpeg-turbo-devel gtk2-devel ncurses-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel
+	$ sudo dnf install automake freetype-devel libpng-devel libjpeg-turbo-devel gtk2-devel ncurses-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel alsa-lib-devel systemd-devel
 
 For NixOS, Follow the instructions [here](./nix/README.md).
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For Arch-based distros:
 
 For Fedora:
 	$ sudo dnf groupinstall "Development Tools"
-	$ sudo dnf install automake freetype-devel libpng-devel libjpeg-turbo-devel gtk2-devel ncurses-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel alsa-lib-devel systemd-devel
+	$ sudo dnf install automake freetype-devel libpng-devel libjpeg-turbo-devel gtk2-devel ncurses-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel alsa-lib-devel systemd-devel gprof2dot
 
 For NixOS, Follow the instructions [here](./nix/README.md).
 


### PR DESCRIPTION
Added the required build dependencies for building Principia on Fedora. I figured since I am using Fedora, I thought I would help since no one else seemed to document it. Except for someone else who made a pull request a few months back, which they said it was broken. But from my end, with the dependencies I added to the README file. It does not seem to be buggy so far. This has been tested on Fedora 37, and it was able to compile and run.

Edit: I know for my first commit I specified RedHat in the title, I realized that it would seem to only work for Fedora.