### PR TITLE
Changed the command for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ For Arch-based distros:
 
 For Fedora:
 
-	$ sudo dnf groupinstall "Development Tools"
-	$ sudo dnf install automake freetype-devel libpng-devel libjpeg-turbo-devel gtk2-devel ncurses-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel alsa-lib-devel systemd-devel gprof2dot
+	$ sudo dnf install @development-tools automake gcc-c++ freetype-devel libpng-devel libjpeg-turbo-devel gtk2-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel alsa-lib-devel systemd-devel gprof2dot
 
 For NixOS, Follow the instructions [here](./nix/README.md).
 


### PR DESCRIPTION
I found that 'sudo dnf install @developement-tools' is equivalent to 'sudo dnf groupinstall "Development Tools"'. And removed 'ncurses-devel' as I found it was added by mistake from one of my previous pull requests. And I added 'gcc-c++' as it is needed for Principia to compile on Fedora. I had to make this pull request again, as there were some merging conflicts between this repository and my fork of this repository.