### PR TITLE
Missing 'libcurl-devel' for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For Arch-based distros:
 
 For Fedora:
 
-	$ sudo dnf install @development-tools automake gcc-c++ freetype-devel libpng-devel libjpeg-turbo-devel gtk2-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel alsa-lib-devel systemd-devel gprof2dot
+	$ sudo dnf install @development-tools automake gcc-c++ freetype-devel libcurl-devel libpng-devel libjpeg-turbo-devel gtk2-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel alsa-lib-devel systemd-devel gprof2dot
 
 For NixOS, Follow the instructions [here](./nix/README.md).
 


### PR DESCRIPTION
When I was compiling Principia on another device with Fedora, I found that I was missing 'libcurl-devel'. And I didn't notice that missing dependency until I built Principia on another Fedora system.