### PR TITLE
Set foreign automake flavour

### DIFF
--- a/build-linux/configure.ac
+++ b/build-linux/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.59)
 AC_INIT([principia], 1, [sdac@bithack.se])
-AM_INIT_AUTOMAKE([subdir-objects])
+AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
 
 AC_PROG_CC


### PR DESCRIPTION
The project doesn't follow the gnu flavour
(no NEWS, AUTHORS, ... files), so "foreign" is more appropriate