### PR TITLE
Do not pass CXX flags as CPP flags

### DIFF
--- a/build-linux/go
+++ b/build-linux/go
@@ -111,13 +111,11 @@ done
 if [ "$release" -eq "1" ]; then
     CFLAGS="$RELEASEFLAGS_CC"
     CXXFLAGS="$RELEASEFLAGS_CXX"
-    CPPFLAGS="$RELEASEFLAGS_CXX"
     LDFLAGS="$RELEASEFLAGS_LD"
 else
     CFLAGS="$DEBUGFLAGS_CC"
     LDFLAGS="$DEBUGFLAGS_LD"
     CXXFLAGS="$DEBUGFLAGS_CXX"
-    CPPFLAGS="$DEBUGFLAGS_CXX"
 fi
 
 if [ "$do_test" -eq "1" ]; then


### PR DESCRIPTION
I assume that was not done on purpose since they are two different things (c++ and preprocessor) and there are already variables for shared flags (RELEASE_SHARED and DEBUG_SHARED). If otherwise please close