### PR TITLE
Added 'glew-devel' for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For Arch-based distros:
 
 For Fedora:
 
-	$ sudo dnf install @development-tools automake gcc-c++ freetype-devel libcurl-devel libpng-devel libjpeg-turbo-devel gtk2-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel alsa-lib-devel systemd-devel
+	$ sudo dnf install @development-tools automake gcc-c++ freetype-devel libcurl-devel libpng-devel libjpeg-turbo-devel gtk2-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel glew-devel alsa-lib-devel systemd-devel
 
 For NixOS, Follow the instructions [here](./nix/README.md).
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For Arch-based distros:
 
 For Fedora:
 
-	$ sudo dnf install @development-tools automake gcc-c++ freetype-devel libcurl-devel libpng-devel libjpeg-turbo-devel gtk2-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel glew-devel alsa-lib-devel systemd-devel
+	$ sudo dnf install @development-tools automake gcc-c++ freetype-devel libcurl-devel libpng-devel libjpeg-turbo-devel gtk2-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel glew-devel mesa-libGL-devel alsa-lib-devel systemd-devel
 
 For NixOS, Follow the instructions [here](./nix/README.md).
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For Arch-based distros:
 
 For Fedora:
 
-	$ sudo dnf install @development-tools automake gcc-c++ freetype-devel libcurl-devel libpng-devel libjpeg-turbo-devel gtk2-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel glew-devel mesa-libGL-devel alsa-lib-devel systemd-devel
+	$ sudo dnf install @development-tools automake gcc-c++ freetype-devel libcurl-devel libpng-devel libjpeg-turbo-devel gtk2-devel SDL2-devel SDL2_image-devel SDL2_gfx-devel SDL2_ttf-devel SDL2_mixer-devel valgrind-devel libXxf86vm-devel glew-devel  mesa-libGLU-devel alsa-lib-devel systemd-devel
 
 For NixOS, Follow the instructions [here](./nix/README.md).
 


### PR DESCRIPTION
When I was recompiling Principia on Fedora, I found there was an error when compiling. When I looked on the dependencies for other Linux systems and the compile error message, I found that I was missing 'libglew'. I looked for the package, installed it, and it was able to compile on Fedora.