### PR TITLE
Add more lua functions

### DIFF
--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -4396,7 +4396,7 @@ static const luaL_Reg entity_methods[] = {
     {"set_color",               l_entity_set_color},            // 1.5
     {"get_color",               l_entity_get_color},            // 1.5
     {"disconnect_all",          l_entity_disconnect_all},       // 1.5
-    //TODO: l_entity_disconnect_all: disconnect specified entity only
+    //TODO: l_entity_disconnect: disconnect specified entity only
     {"set_target_id",           l_entity_set_target_id},        // 1.5
 
     /* we pretend this is creature stuff */

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -2136,6 +2136,7 @@ extern "C" {
      * Added in 1.5.2
      * entity:apply_force(x, y, [point_x, point_y])
      * 
+     * Apply force x,y at point point_x, point_y (optional)
      **/
     static int l_entity_apply_force(lua_State *L)
     {   

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -1148,8 +1148,11 @@ extern "C" {
         }
 
         //Emit entity
-        G->emit(ent);
-        W->emit_all();
+        //XXX: Should post_emit be used here instead?
+        //XXX: do we actually need to commit all pending emits here? 
+        //XXX: Likely yes (scripts expect valid, spawned entities)
+        G->emit(ent); 
+        W->emit_all(); 
 
         //Return entity
         entity **ee = static_cast<entity**>(lua_newuserdata(L, sizeof(entity*)));

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -1806,7 +1806,7 @@ extern "C" {
         //TODO: check if argument exists? (default to true?)
         bool is_fixed = lua_toboolean(L, 2); 
 
-        b2Body *b = e->get_body(0); //XXX: enable for all bodies? (e.g. like in a ragdoll)
+        b2Body *b = e->get_body(0);
 
         if (b) {
           //XXX: SetFixedRotation resets mass???
@@ -1839,6 +1839,65 @@ extern "C" {
 
         if (b) {
             lua_pushboolean(L, b->IsFixedRotation());
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /** 
+     * added in 1.5.2
+     * entity:set_gravity_scale(number)
+     *
+     * Example usage:
+     * entity:set_gravity_scale(0.5)
+     * 
+     * EXPERIMENTAL: Set the gravity scale of the given object
+     **/
+    static int l_entity_set_gravity_scale(lua_State *L)
+    {
+        //TODO: change this to LEVEL_VERSION_1_5_2 / "1.5.2" after release
+        if (W->level.version < LEVEL_VERSION_1_5_1) {
+            ESCRIPT_VERSION_ERROR(L, "entity:set_gravity_scale", "1.5.1");
+            return 0;
+        }
+
+        entity *e = *(static_cast<entity**>(luaL_checkudata(L, 1, "EntityMT")));
+
+        float new_gravity_scale = luaL_checknumber(L, 2);
+
+        b2Body *b = e->get_body(0);
+
+        if (b) {
+          b->SetGravityScale(new_gravity_scale);
+        }
+
+        return 0;
+    }
+
+    /** 
+     * added in 1.5.2
+     * entity:get_gravity_scale()
+     *
+     * Example usage:
+     * x = entity:get_gravity_scale()
+     * 
+     * EXPERIMENTAL: Get the gravity scale of the given object
+     **/
+    static int l_entity_get_gravity_scale(lua_State *L)
+    {
+        //TODO: change this to LEVEL_VERSION_1_5_2 / "1.5.2" after release
+        if (W->level.version < LEVEL_VERSION_1_5_1) {
+            ESCRIPT_VERSION_ERROR(L, "entity:get_gravity_scale", "1.5.1");
+            return 0;
+        }
+
+        entity *e = *(static_cast<entity**>(luaL_checkudata(L, 1, "EntityMT")));
+
+        b2Body *b = e->get_body(0);
+
+        if (b) {
+            lua_pushnumber(L, b->GetGravityScale());
             return 1;
         }
 
@@ -4426,6 +4485,8 @@ static const luaL_Reg entity_methods[] = {
     {"set_angle",               l_entity_set_angle},			// 1.5.2 (oss)
     {"set_fixed_rotation",      l_entity_set_fixed_rotation},	// 1.5.2 (oss) 
     {"is_fixed_rotation",       l_entity_is_fixed_rotation},	// 1.5.2 (oss) 
+    {"set_gravity_scale",       l_entity_set_gravity_scale},	// 1.5.2 (oss) 
+    {"get_gravity_scale",       l_entity_get_gravity_scale},	// 1.5.2 (oss) 
     {"get_velocity",            l_entity_get_velocity},
     {"get_angular_velocity",    l_entity_get_angular_velocity},
     {"get_bbox",                l_entity_get_bbox},

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -933,6 +933,25 @@ extern "C" {
     }
 
     /** 
+     * Added in 1.5.2
+     * world:set_gravity(x, y)
+     **/
+    static int l_world_set_gravity(lua_State *L)
+    {
+        //TODO: change this to LEVEL_VERSION_1_5_2 / "1.5.2" after release
+        if (W->level.version < LEVEL_VERSION_1_5_1) {
+            ESCRIPT_VERSION_ERROR(L, "world:get_gravity", "1.5.1");
+            return 0;
+        }
+
+        float x = luaL_checknumber(L, 2);
+        float y = luaL_checknumber(L, 3);
+        W->set_gravity(x, y);
+
+        return 0;
+    }
+
+    /** 
      * Added in 1.5
      * id = world:get_adventure_id()
      *
@@ -4202,6 +4221,7 @@ static const luaL_Reg world_methods[] = {
     {"raycast",                 l_world_raycast},           // 1.4
     {"query",                   l_world_query},             // 1.4
     {"get_gravity",             l_world_get_gravity},       // 1.4
+    {"set_gravity",             l_world_set_gravity},       // 1.5.2 (oss)
 
     {"get_adventure_id",        l_world_get_adventure_id},  // 1.5
     {"get_borders",             l_world_get_borders},       // 1.5

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -1852,7 +1852,7 @@ extern "C" {
      * Example usage:
      * entity:set_gravity_scale(0.5)
      * 
-     * EXPERIMENTAL: Set the gravity scale of the given object
+     * Set the gravity scale of the given object
      **/
     static int l_entity_set_gravity_scale(lua_State *L)
     {
@@ -1882,7 +1882,7 @@ extern "C" {
      * Example usage:
      * x = entity:get_gravity_scale()
      * 
-     * EXPERIMENTAL: Get the gravity scale of the given object
+     * Get the gravity scale of the given object
      **/
     static int l_entity_get_gravity_scale(lua_State *L)
     {

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -1838,8 +1838,8 @@ extern "C" {
         b2Body *b = e->get_body(0);
 
         if (b) {
-          lua_pushboolean(L, b->IsFixedRotation());
-          return 1;
+            lua_pushboolean(L, b->IsFixedRotation());
+            return 1;
         }
 
         return 0;
@@ -4423,9 +4423,9 @@ static const luaL_Reg entity_methods[] = {
     {"get_g_id",                l_entity_get_g_id},
     {"get_position",            l_entity_get_position},
     {"get_angle",               l_entity_get_angle},
-    {"set_angle",               l_entity_set_angle},			      // 1.5.2 (oss)
-    {"set_fixed_rotation",      l_entity_set_fixed_rotation},		// 1.5.2 (oss) 
-    {"is_fixed_rotation",       l_entity_is_fixed_rotation},		// 1.5.2 (oss) 
+    {"set_angle",               l_entity_set_angle},			// 1.5.2 (oss)
+    {"set_fixed_rotation",      l_entity_set_fixed_rotation},	// 1.5.2 (oss) 
+    {"is_fixed_rotation",       l_entity_is_fixed_rotation},	// 1.5.2 (oss) 
     {"get_velocity",            l_entity_get_velocity},
     {"get_angular_velocity",    l_entity_get_angular_velocity},
     {"get_bbox",                l_entity_get_bbox},

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -4482,7 +4482,7 @@ static const luaL_Reg entity_methods[] = {
     {"get_g_id",                l_entity_get_g_id},
     {"get_position",            l_entity_get_position},
     {"get_angle",               l_entity_get_angle},
-    {"set_angle",               l_entity_set_angle},			// 1.5.2 (oss)
+    {"set_angle",               l_entity_set_angle},            // 1.5.2 (oss)
     {"set_fixed_rotation",      l_entity_set_fixed_rotation},	// 1.5.2 (oss) 
     {"is_fixed_rotation",       l_entity_is_fixed_rotation},	// 1.5.2 (oss) 
     {"set_gravity_scale",       l_entity_set_gravity_scale},	// 1.5.2 (oss) 

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -940,7 +940,7 @@ extern "C" {
     {
         //TODO: change this to LEVEL_VERSION_1_5_2 / "1.5.2" after release
         if (W->level.version < LEVEL_VERSION_1_5_1) {
-            ESCRIPT_VERSION_ERROR(L, "world:get_gravity", "1.5.1");
+            ESCRIPT_VERSION_ERROR(L, "world:set_gravity", "1.5.1");
             return 0;
         }
 
@@ -2132,6 +2132,46 @@ extern "C" {
         return 0;
     }
 
+    /** 
+     * Added in 1.5.2
+     * entity:apply_force(x, y, [point_x, point_y])
+     * 
+     **/
+    static int l_entity_apply_force(lua_State *L)
+    {   
+        //TODO: change this to LEVEL_VERSION_1_5_2 / "1.5.2" after release
+        if (W->level.version < LEVEL_VERSION_1_5_1) {
+            ESCRIPT_VERSION_ERROR(L, "entity:apply_force", "1.5.1");
+            return 0;
+        }
+
+        entity *e = *(static_cast<entity**>(luaL_checkudata(L, 1, "EntityMT")));
+        float x = luaL_checknumber(L, 2);
+        float y = luaL_checknumber(L, 3);
+        float px, py;
+        if (lua_gettop(L) > 3) {
+            px = luaL_checknumber(L, 4);
+            py = luaL_checknumber(L, 5);
+        }
+
+        b2Vec2 force(x, y);
+        b2Vec2 point(x, y);
+
+        for (uint32_t x = 0; x < e->get_num_bodies(); ++x) {
+            b2Body *b = e->get_body(x);
+
+            if (b) {
+                if (lua_gettop(L) > 3) {
+                    b->ApplyForce(force, point);
+                } else {
+                    b->ApplyForceToCenter(force);
+                }
+            }
+        }
+
+        return 0;
+    }
+    
     /** 
      * Added in 1.5
      * entity:set_velocity(x, y)
@@ -4486,7 +4526,7 @@ static const luaL_Reg entity_methods[] = {
     {"set_fixed_rotation",      l_entity_set_fixed_rotation},	// 1.5.2 (oss) 
     {"is_fixed_rotation",       l_entity_is_fixed_rotation},	// 1.5.2 (oss) 
     {"set_gravity_scale",       l_entity_set_gravity_scale},	// 1.5.2 (oss) 
-    {"get_gravity_scale",       l_entity_get_gravity_scale},	// 1.5.2 (oss) 
+    {"get_gravity_scale",       l_entity_get_gravity_scale},	// 1.5.2 (oss)
     {"get_velocity",            l_entity_get_velocity},
     {"get_angular_velocity",    l_entity_get_angular_velocity},
     {"get_bbox",                l_entity_get_bbox},
@@ -4501,6 +4541,8 @@ static const luaL_Reg entity_methods[] = {
     {"apply_torque",            l_entity_apply_torque},         // 1.5
     {"set_velocity",            l_entity_set_velocity},         // 1.5
     {"set_angular_velocity",    l_entity_set_angular_velocity}, // 1.5.2 (oss)
+    {"apply_force",             l_entity_apply_force},          // 1.5.2 (oss)
+    //TODO: apply_impulse, apply_angular_impulse
     {"warp",                    l_entity_warp},                 // 1.5
     {"show",                    l_entity_show},                 // 1.5
     {"hide",                    l_entity_hide},                 // 1.5

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -1788,6 +1788,38 @@ extern "C" {
         return 0;
     }
 
+    /** 
+     * added in 1.5.2
+     * entity:set_fixed_rotation(bool)
+     *
+     * Example usage:
+     * entity:set_fixed_rotation(true)
+     *
+     * EXPERIMENTAL: Prevents entity from rotating
+     **/
+    static int l_entity_set_fixed_rotation(lua_State *L)
+    {
+        //TODO: change this to LEVEL_VERSION_1_5_2 / "1.5.2" after release
+        if (W->level.version < LEVEL_VERSION_1_5_1) {
+            ESCRIPT_VERSION_ERROR(L, "entity:set_fixed_rotation", "1.5.1");
+            return 0;
+        }
+
+        entity *e = *(static_cast<entity**>(luaL_checkudata(L, 1, "EntityMT")));
+
+        //TODO: check if argument exists? (default to true?)
+        bool is_fixed = lua_toboolean(L, 2); 
+
+        b2Body *b = e->get_body(0);
+
+        if (b) {
+          //XXX: SetFixedRotation resets mass???
+          b->SetFixedRotation(is_fixed); 
+        }
+
+        return 0;
+    }
+
     /* added in 1.4 */
     static int l_entity_local_to_world(lua_State *L)
     {
@@ -4367,6 +4399,8 @@ static const luaL_Reg entity_methods[] = {
     {"get_position",            l_entity_get_position},
     {"get_angle",               l_entity_get_angle},
     {"set_angle",               l_entity_set_angle},			      // 1.5.2 (oss)
+    {"set_fixed_rotation",      l_entity_set_fixed_rotation},		// 1.5.2 (oss) 
+    //TODO get_fixed_rotation
     {"get_velocity",            l_entity_get_velocity},
     {"get_angular_velocity",    l_entity_get_angular_velocity},
     {"get_bbox",                l_entity_get_bbox},

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -1791,7 +1791,7 @@ extern "C" {
      * Example usage:
      * entity:set_fixed_rotation(true)
      *
-     * EXPERIMENTAL: Prevents entity from rotating
+     * EXPERIMENTAL: Prevents entity from rotating.
      **/
     static int l_entity_set_fixed_rotation(lua_State *L)
     {
@@ -1806,11 +1806,40 @@ extern "C" {
         //TODO: check if argument exists? (default to true?)
         bool is_fixed = lua_toboolean(L, 2); 
 
-        b2Body *b = e->get_body(0);
+        b2Body *b = e->get_body(0); //XXX: enable for all bodies? (e.g. like in a ragdoll)
 
         if (b) {
           //XXX: SetFixedRotation resets mass???
           b->SetFixedRotation(is_fixed); 
+        }
+
+        return 0;
+    }
+
+    /** 
+     * added in 1.5.2
+     * entity:is_fixed_rotation()
+     *
+     * Example usage:
+     * x = entity:is_fixed_rotation()
+     *
+     * EXPERIMENTAL: Returns true if the given socket has fixed rotation enabled.
+     **/
+    static int l_entity_is_fixed_rotation(lua_State *L)
+    {
+        //TODO: change this to LEVEL_VERSION_1_5_2 / "1.5.2" after release
+        if (W->level.version < LEVEL_VERSION_1_5_1) {
+            ESCRIPT_VERSION_ERROR(L, "entity:is_fixed_rotation", "1.5.1");
+            return 0;
+        }
+
+        entity *e = *(static_cast<entity**>(luaL_checkudata(L, 1, "EntityMT")));
+
+        b2Body *b = e->get_body(0);
+
+        if (b) {
+          lua_pushboolean(L, b->IsFixedRotation());
+          return 1;
         }
 
         return 0;
@@ -4396,7 +4425,7 @@ static const luaL_Reg entity_methods[] = {
     {"get_angle",               l_entity_get_angle},
     {"set_angle",               l_entity_set_angle},			      // 1.5.2 (oss)
     {"set_fixed_rotation",      l_entity_set_fixed_rotation},		// 1.5.2 (oss) 
-    //TODO get_fixed_rotation
+    {"is_fixed_rotation",       l_entity_is_fixed_rotation},		// 1.5.2 (oss) 
     {"get_velocity",            l_entity_get_velocity},
     {"get_angular_velocity",    l_entity_get_angular_velocity},
     {"get_bbox",                l_entity_get_bbox},

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -1758,8 +1758,15 @@ extern "C" {
         return 1;
     }
 	
-    /* added in 1.5.2 */
-
+    /** 
+     * added in 1.5.2
+     * entity:set_angle()
+     *
+     * Example usage:
+     * entity:set_angle(angle)
+     *
+     * Set the angle of the entity
+     **/
     static int l_entity_set_angle(lua_State *L)
     {
         //TODO: change this to LEVEL_VERSION_1_5_2 / "1.5.2" after release
@@ -4389,11 +4396,12 @@ static const luaL_Reg entity_methods[] = {
     {"set_color",               l_entity_set_color},            // 1.5
     {"get_color",               l_entity_get_color},            // 1.5
     {"disconnect_all",          l_entity_disconnect_all},       // 1.5
+    //TODO: l_entity_disconnect_all: disconnect specified entity only
     {"set_target_id",           l_entity_set_target_id},        // 1.5
 
     /* we pretend this is creature stuff */
     {"get_hp",                  l_creature_get_hp},             // 1.5
-    //TODO: l_creature_set_hp
+    //TODO: l_creature_set_hp: sets the hp of entity
     {"get_armor",               l_creature_get_armor},          // 1.5
     {"get_aim",                 l_creature_get_aim},            // 1.5
     {"set_aim",                 l_creature_set_aim},            // 1.5

--- a/src/src/escript.cc
+++ b/src/src/escript.cc
@@ -1749,10 +1749,6 @@ extern "C" {
      **/
     static int l_entity_get_angle(lua_State *L)
     {
-        if (W->level.version < LEVEL_VERSION_1_4) {
-            ESCRIPT_VERSION_ERROR(L, "entity:local_to_world", "1.4");
-            return 0;
-        }
         entity *e = *(static_cast<entity**>(luaL_checkudata(L, 1, "EntityMT")));
         lua_pushnumber(L, e->get_angle());
         return 1;


### PR DESCRIPTION
Added lua api functions (Mostly related to entities):

## World:

* `world:set_gravity(x: number, y: number)`  
* `world:emit(g_id, [id]) --> entity` (experimental) 
 
## Entity:

* `entity:set_angle(angle: number)`   
* `entity:set_angular_velocity(velocity: number)`  
* `entity:is_hidden() --> boolean`  
* `entity:set_fixed_rotation(enable: boolean)` (experimental)  
* `entity:is_fixed_rotation() --> boolean` (experimental)  
* `entity:set_gravity_scale(scale: number)`
* `entity:get_gravity_scale() --> number`
* `entity:apply_force(x, y, [point_x, point_y])`


(for `world:emit()` - #109 should be merged first to prevent crashes)
  
I added checks for 1.5.1 because there's no level version code for 1.5.2 yet.
fix this after 1.5.2 release.