### PR TITLE
Fix `create_with_id` segfault

### DIFF
--- a/src/src/object_factory.cc
+++ b/src/src/object_factory.cc
@@ -980,9 +980,12 @@ of::create_with_id(p_gid g_id, p_id id)
 {
     entity *e = _create(g_id);
 
-    e->id = id;
-
-    return e;
+    if (e) {
+        e->id = id;
+        return e;
+    }
+    
+    return 0;
 }
 
 /* IMPORTANT: keep this in sync with

--- a/src/src/ui.cc
+++ b/src/src/ui.cc
@@ -10424,7 +10424,6 @@ int _gtk_loop(void *p)
                 "Empty Adventure", RESPONSE_EMPTY_ADVENTURE,
                 "Adventure", RESPONSE_ADVENTURE,
                 "Custom", RESPONSE_CUSTOM,
-                "Puzzle", RESPONSE_PUZZLE,
                 NULL));
 
         apply_defaults(new_level_dialog);

--- a/src/src/ui.cc
+++ b/src/src/ui.cc
@@ -10424,6 +10424,7 @@ int _gtk_loop(void *p)
                 "Empty Adventure", RESPONSE_EMPTY_ADVENTURE,
                 "Adventure", RESPONSE_ADVENTURE,
                 "Custom", RESPONSE_CUSTOM,
+                "Puzzle", RESPONSE_PUZZLE,
                 NULL));
 
         apply_defaults(new_level_dialog);


### PR DESCRIPTION
Return a null pointer instead of segfaulting.  
The game actually checks the result of this function and gracefully shuts down if it returns a null pointer.