### PR TITLE
Fix `create_with_id` segfault

### DIFF
--- a/src/src/object_factory.cc
+++ b/src/src/object_factory.cc
@@ -979,9 +979,11 @@ entity*
 of::create_with_id(p_gid g_id, p_id id)
 {
     entity *e = _create(g_id);
-
-    e->id = id;
-
+    
+    if (e) {
+        e->id = id;
+    }
+    
     return e;
 }
 


### PR DESCRIPTION
Check for null pointer before setting the entity id