### PR TITLE
fix IF-select socket positions

### DIFF
--- a/src/src/iomiscgate.cc
+++ b/src/src/iomiscgate.cc
@@ -201,6 +201,14 @@ i4o1gate::i4o1gate()
     this->set_as_rect(.375f, .375f);
 }
 
+ifselect::ifselect()
+: i3o1gate() {
+    this->s_in[0].lpos  = b2Vec2(-.25f, -.125f);
+    this->s_in[1].lpos  = b2Vec2(  0.f, -.125f);
+    this->s_in[2].lpos  = b2Vec2( .25f, -.125f);
+    this->s_out[0].lpos = b2Vec2(  0.f,  .125f);
+}
+
 edevice*
 ifselect::solve_electronics()
 {

--- a/src/src/iomiscgate.hh
+++ b/src/src/iomiscgate.hh
@@ -60,6 +60,7 @@ class i4o1gate : public brcomp_multiconnect
 class ifselect : public i3o1gate
 {
   public:
+    ifselect();
     const char *get_name(){return "IF-select";}
     edevice *solve_electronics();
 };


### PR DESCRIPTION
Fix positions of input/output sockets on IF-select     
  

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/45996170/233218825-19b5ef2f-5ff2-434f-b89f-40fcb1979464.png" alt="before-image" height="240"></td>
    <td><img src="https://user-images.githubusercontent.com/45996170/233218832-5f706f3b-3d8f-413a-8e5a-5d5dbe9490e5.png" alt="after-image" height="240"></td>
  </tr>
</table>  
  

This shouldn't break compatability, but we should probably still gate it behind the 1.5.2 level version after the release.