### PR TITLE
Increase fluid buffer size

### DIFF
--- a/src/src/Box2D/Common/b2Settings.h
+++ b/src/src/Box2D/Common/b2Settings.h
@@ -122,7 +122,7 @@ typedef double float64;
 
 // Particle
 //
-#define b2_maxParticles             4096
+#define b2_maxParticles             65536
 
 /// A symbolic constant that stands for particle allocation error.
 #define b2_invalidParticleIndex		(-1)

--- a/src/src/fluid.cc
+++ b/src/src/fluid.cc
@@ -3,6 +3,9 @@
 #include "model.hh"
 #include "world.hh"
 
+#define MAX_PARTICLES_1_5_1 4096
+#define MAX_PARTICLES       b2_maxParticles
+
 fluid::fluid()
 {
     this->set_flag(ENTITY_IS_BETA, true);
@@ -90,6 +93,7 @@ fluid::add_to_world()
         W->b2->SetParticleRadius(.2f);
         W->b2->SetParticleDamping(.35f);
         W->b2->SetParticleDensity(1.0f);
+        W->b2->SetParticleMaxCount((W->level.version <= LEVEL_VERSION_1_5_1) ? MAX_PARTICLES_1_5_1 : MAX_PARTICLES);
         pd.flags = ((2+4) << (16+4*this->get_layer()));
         //pd.flags = b2_waterParticle | (15 << (16+4*this->get_layer()));
         //pd.flags = b2_elasticParticle | (15 << (16+4*this->get_layer()));
@@ -107,4 +111,3 @@ fluid::add_to_world()
     this->width = this->get_width();
     this->height = this->get_width();
 }
-

--- a/src/src/fluidbuffer.cc
+++ b/src/src/fluidbuffer.cc
@@ -1,4 +1,5 @@
 #include "fluidbuffer.hh"
+#include "game.hh"
 
 static tms::gbuffer *verts;
 static tms::gbuffer *indices;
@@ -7,7 +8,7 @@ static tms::mesh *mesh;
 static tms::entity *e;
 static tms::entity *e2;
 
-static int n = 0;
+static uint32_t n = 0;
 
 struct vert {
     tvec3 pos;
@@ -39,6 +40,7 @@ fluidbuffer::get_entity()
 
     return e;
 }
+
 void fluidbuffer::_init()
 {
     tms_progressf("Initializing fluidbuffer... ");
@@ -90,43 +92,38 @@ void fluidbuffer::_init()
     tms_progressf("OK\n");
 }
 
-/*
-void
-fluidbuffer::add(float x, float y, float z,
-        float r, float g, float b, float a,
-        float w, float h)
+void fluidbuffer::add(
+    float x, float y, float z,
+    //float r, float g, float b, float a,
+    float pressure,
+    float w, float h
+) {
+    uint32_t particle_limit = ((W->level.version <= LEVEL_VERSION_1_5_1) ? FLUIDBUFFER_MAX_1_5_1 : FLUIDBUFFER_MAX);
+    if (n >= particle_limit) return;
+    
+    struct vert *vert_buf = (struct vert*) verts->get_buffer();
+    for (int ix=0; ix<4; ix++) {
+        vert_buf[n*4+ix] = base[ix];
+
+        vert_buf[n*4+ix].pos.x *= w;
+        vert_buf[n*4+ix].pos.y *= h;
+
+        vert_buf[n*4+ix].pos.x += x;
+        vert_buf[n*4+ix].pos.y += y;
+        vert_buf[n*4+ix].pos.z += z;
+
+        /*
+        vert_buf[n*4+ix].color.r = r;
+        vert_buf[n*4+ix].color.g = g;
+        vert_buf[n*4+ix].color.b = b;
+        vert_buf[n*4+ix].color.a = a;
         */
-void
-fluidbuffer::add(float x, float y, float z,
-        //float r, float g, float b, float a,
-        float pressure,
-        float w, float h)
-{
-    if (n < FLUIDBUFFER_MAX) {
-        struct vert *_b = (struct vert*)verts->get_buffer();
-        for (int ix=0; ix<4; ix++) {
-            _b[n*4+ix] = base[ix];
 
-            _b[n*4+ix].pos.x *= w;
-            _b[n*4+ix].pos.y *= h;
-
-            _b[n*4+ix].pos.x += x;
-            _b[n*4+ix].pos.y += y;
-            _b[n*4+ix].pos.z += z;
-
-            /*
-            _b[n*4+ix].color.r = r;
-            _b[n*4+ix].color.g = g;
-            _b[n*4+ix].color.b = b;
-            _b[n*4+ix].color.a = a;
-            */
-
-            _b[n*4+ix].uv.x += .5f*(3%2);
-            _b[n*4+ix].uv.y -= .25f*(3/2);
-            _b[n*4+ix].uv.z = pressure;
-        }
-        n++;
+        vert_buf[n*4+ix].uv.x += .5f*(3%2);
+        vert_buf[n*4+ix].uv.y -= .25f*(3/2);
+        vert_buf[n*4+ix].uv.z = pressure;
     }
+    n++;
 }
 
 void fluidbuffer::upload()

--- a/src/src/fluidbuffer.cc
+++ b/src/src/fluidbuffer.cc
@@ -26,9 +26,10 @@ fluidbuffer::get_entity()
 {
     if (e) return e;
 
-    e = new tms::entity();
     mesh = new tms::mesh(va, indices);
-
+    mesh->i32 = 1;
+    
+    e = new tms::entity();
     e->prio = 0;
     e->set_mesh(mesh);
     e->set_material(&m_fluidbuf);
@@ -38,7 +39,6 @@ fluidbuffer::get_entity()
 
     return e;
 }
-
 void fluidbuffer::_init()
 {
     tms_progressf("Initializing fluidbuffer... ");
@@ -46,17 +46,17 @@ void fluidbuffer::_init()
     verts = new tms::gbuffer(4*(FLUIDBUFFER_MAX)*sizeof(struct vert));
     verts->usage = TMS_GBUFFER_STREAM_DRAW;
 
-    indices = new tms::gbuffer(6*FLUIDBUFFER_MAX*sizeof(uint16_t));
+    indices = new tms::gbuffer(6*FLUIDBUFFER_MAX*sizeof(uint32_t));
     indices->usage = TMS_GBUFFER_STATIC_DRAW;
-
+    
     va = new tms::varray(2);
     va->map_attribute("position", 3, GL_FLOAT, verts);
     va->map_attribute("uv", 3, GL_FLOAT, verts);
 
-    uint16_t *i = (uint16_t*)indices->get_buffer();
-    for (int x=0; x<FLUIDBUFFER_MAX; x++) {
-        int o = x*6;
-        int vo = x*4;
+    uint32_t *i = (uint32_t*)indices->get_buffer();
+    for (uint32_t x=0; x<FLUIDBUFFER_MAX; x++) {
+        uint32_t o = x*6;
+        uint32_t vo = x*4;
 
         i[o+0] = vo;
         i[o+1] = vo+1;
@@ -137,4 +137,3 @@ void fluidbuffer::upload()
     }
     if (n) verts->upload_partial(n*4*sizeof(struct vert));
 }
-

--- a/src/src/fluidbuffer.hh
+++ b/src/src/fluidbuffer.hh
@@ -3,7 +3,8 @@
 
 #include "entity.hh"
 
-#define FLUIDBUFFER_MAX b2_maxParticles
+#define FLUIDBUFFER_MAX_1_5_1  4096            // Used in <= 1.5.1
+#define FLUIDBUFFER_MAX        b2_maxParticles // Used in >= 1.5.2
 
 class fluidbuffer
 {

--- a/src/src/fluidbuffer.hh
+++ b/src/src/fluidbuffer.hh
@@ -3,7 +3,7 @@
 
 #include "entity.hh"
 
-#define FLUIDBUFFER_MAX 4096
+#define FLUIDBUFFER_MAX b2_maxParticles
 
 class fluidbuffer
 {

--- a/src/tms/core/graph.c
+++ b/src/tms/core/graph.c
@@ -275,37 +275,18 @@ render_entities(struct tms_rstate *state,
 
         if (m->indices) {
             int start = m->i_start;
-            int c = m->i_count;
+            int count = m->i_count;
 
-            if (c == -1) {
-                c = m->indices->usize / (m->i32?sizeof(int):sizeof(short));
+            if (count == -1) {
+                count = m->indices->usize / (m->i32?sizeof(int):sizeof(short));
             }
 
-            if (c) {
-                int pr = m->primitive_type;
-                /*
-                if (pr == GL_PATCHES && state->p > 0 && state->p != 3)
-                    pr = GL_TRIANGLES;
-                    */
-
-             /*   if (m->v_base != 0) {
-#if !defined TMS_BACKEND_ANDROID && !defined TMS_BACKEND_IOS
-                    glDrawElementsBaseVertex(pr,
-                            c,
-                            (m->i32?GL_UNSIGNED_INT:GL_UNSIGNED_SHORT), (char*)(start*2),
-                            m->v_base
-                            );
-#else
-                    tms_fatalf("base vertices not supported on android");
-#endif
-                } else {
-                */
-                    glDrawElements(pr,
-                            c,
-                            //(m->i32?GL_UNSIGNED_INT:GL_UNSIGNED_SHORT), (char*)(start*2));
-                            GL_UNSIGNED_SHORT, (char*)(start*2));
-                //}
-            }
+            if (count) glDrawElements(
+                m->primitive_type,
+                count,
+                (m->i32?GL_UNSIGNED_INT:GL_UNSIGNED_SHORT), 
+                (char*)(start * (m->i32?sizeof(int):sizeof(short)))
+            );
         } else {
             glDrawArrays(m->primitive_type, 0, m->vertex_array->gbufs[0].gbuf->usize / m->vertex_array->gbufs[0].vsize);
         }

--- a/src/tms/core/mesh.c
+++ b/src/tms/core/mesh.c
@@ -76,17 +76,20 @@ tms_mesh_draw(struct tms_mesh *m)
 
         //tms_infof("start %d, count %d", start, count);
 
-        if (count == -1)
+        if (count == -1) {
             count = m->indices->usize / (m->i32?sizeof(int):sizeof(short));
+        }
 
-        if (count)
-            glDrawElements(m->primitive_type,
-                    count,
-                    (m->i32?GL_UNSIGNED_INT:GL_UNSIGNED_SHORT), (char*)(start*2));
+        if (count) glDrawElements(
+            m->primitive_type,
+            count,
+            (m->i32?GL_UNSIGNED_INT:GL_UNSIGNED_SHORT), 
+            (char*)(start * (m->i32?sizeof(int):sizeof(short)))
+        );
+
         //glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     } else
         glDrawArrays(m->primitive_type, 0, m->vertex_array->gbufs[0].gbuf->usize / m->vertex_array->gbufs[0].vsize);
 
     return T_OK;
 }
-

--- a/src/tms/core/mesh.h
+++ b/src/tms/core/mesh.h
@@ -25,7 +25,7 @@ struct tms_mesh {
     int autofree_bufs;
     int i32;
     int cw;
-    int i_start; /* in sizeof(uint16_t) */
+    int i_start; /* in elements */
     int i_count;
     int v_base;
     int id; /* Unique identifier of mesh, optional */


### PR DESCRIPTION
closes #67 

increases the max amount of fluid by 16 times.

- fixed `mesh->i32` (32 bit buffer) support  
- switched to a i32 mesh for fluids   
- increased box2d particle limit to 65536  
- increased fluid buffer size to match the box2d limit  

doesn't break compatability completely (levels can still be loaded) but can affect amount of water spawned.

waiting for the version code increase

letest comit checks for <= 1.5.1