### PR TITLE
Improve sticky note text rendering

### DIFF
--- a/build-android/principia/src/main/java/com/bithack/principia/shared/Settings.java
+++ b/build-android/principia/src/main/java/com/bithack/principia/shared/Settings.java
@@ -19,6 +19,7 @@ public class Settings
 
     public boolean enable_ao;
     public int texture_quality;
+    public boolean sticky_note_quality;
     public boolean display_object_ids;
     public boolean display_grapher_value;
     public boolean display_wireless_frequency;

--- a/build-android/principia/src/main/java/com/bithack/principia/shared/SettingsDialog.java
+++ b/build-android/principia/src/main/java/com/bithack/principia/shared/SettingsDialog.java
@@ -33,6 +33,7 @@ public class SettingsDialog implements OnSeekBarChangeListener, OnClickListener 
     final SeekBar settings_cam_speed;
     final SeekBar settings_zoom_speed;
     final CheckBox cb_enableshadows;
+    final CheckBox checkbox_sticky_note_res;
     final RadioGroup rg_ao;
     final RadioGroup rg_texture_quality;
     final RadioGroup rg_fps;
@@ -88,6 +89,7 @@ public class SettingsDialog implements OnSeekBarChangeListener, OnClickListener 
         sb_uiscale = (SeekBar)view.findViewById(R.id.settings_uiscale);
         rg_ao = (RadioGroup)view.findViewById(R.id.radiogroup_ao);
         rg_texture_quality = (RadioGroup)view.findViewById(R.id.tex_quality);
+        checkbox_sticky_note_res = (CheckBox)view.findViewById(R.id.checkbox_sticky_note_res);
         rg_fps = (RadioGroup)view.findViewById(R.id.rg_fps);
         cb_enableshadows = (CheckBox)view.findViewById(R.id.checkbox_enableshadows);
 
@@ -182,6 +184,8 @@ public class SettingsDialog implements OnSeekBarChangeListener, OnClickListener 
         float border_scroll_speed_base = (float)this.settings_border_scroll_speed.getProgress() / 10.f;
         float border_scroll_speed = border_scroll_speed_base + 0.5f;
 
+        boolean sticky_note_quality = checkbox_sticky_note_res.isChecked();
+
         switch (rg_ao.getCheckedRadioButtonId()) {
             case R.id.rg_values_off: enable_ao = false; break;
             case R.id.rg_values_low: ao_map_res = 128; break;
@@ -222,7 +226,7 @@ public class SettingsDialog implements OnSeekBarChangeListener, OnClickListener 
                                      display_object_ids, display_grapher_value, display_wireless_frequency,
                                      volume, muted,
                                      hide_tips, sandbox_back_dna,
-                                     display_fps);
+                                     display_fps, sticky_note_quality);
     }
 
     public void load()
@@ -276,6 +280,8 @@ public class SettingsDialog implements OnSeekBarChangeListener, OnClickListener 
         } else {
             rg_texture_quality.check(R.id.tex_low);
         }
+
+        checkbox_sticky_note_res.setChecked(s.sticky_note_quality);
 
         int uiscale_step = (int)Math.round((((double)s.uiscale - 0.5) * 10.0));
 

--- a/build-android/principia/src/main/java/org/libsdl/app/PrincipiaBackend.java
+++ b/build-android/principia/src/main/java/org/libsdl/app/PrincipiaBackend.java
@@ -48,7 +48,8 @@ public class PrincipiaBackend
             boolean muted,
             boolean hide_tips,
             boolean sandbox_back_dna,
-            int display_fps
+            int display_fps,
+            boolean sticky_note_quality
                 );
     public static native Settings getSettings();
     public static native boolean getSettingBool(String setting_name);

--- a/build-android/principia/src/main/res/layout/settings.xml
+++ b/build-android/principia/src/main/res/layout/settings.xml
@@ -240,6 +240,12 @@
                     android:text="@string/high" />
             </RadioGroup>
 
+            <CheckBox
+                android:id="@+id/checkbox_sticky_note_res"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/sticky_note_res" />
+            
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/build-android/principia/src/main/res/values/strings.xml
+++ b/build-android/principia/src/main/res/values/strings.xml
@@ -163,6 +163,7 @@
     <string name="advanced">Advanced</string>
     <string name="ambient_occlusion">Ambient occlusion</string>
     <string name="enable_shadows">Enable shadows</string>
+    <string name="sticky_note_res">Increase sticky note resolution</string>
     <string name="NA">N/A</string>
     <string name="off">Off</string>
     <string name="on">On</string>

--- a/src/src/settings.cc
+++ b/src/src/settings.cc
@@ -108,7 +108,12 @@ _settings::init()
     this->add("render_gui",         S_BOOL,  true);
     this->add("texture_quality",    S_UINT8,  (this->_data["window_width"]->v.i < 1024 ? 0 : 2));
     this->add("render_edev_labels", S_BOOL,  true);
-
+    
+#ifdef TMS_BACKEND_PC
+    this->add("sticky_note_hd", S_BOOL, !is_shitty);
+#else
+    this->add("sticky_note_hd", S_BOOL, false);
+#endif
 
     this->add("fv",                 S_INT32,   1); /* settings file version */
     this->add("jail_cursor",        S_BOOL,  false);

--- a/src/src/settings.cc
+++ b/src/src/settings.cc
@@ -110,9 +110,9 @@ _settings::init()
     this->add("render_edev_labels", S_BOOL,  true);
     
 #ifdef TMS_BACKEND_PC
-    this->add("sticky_note_hd", S_BOOL, !is_shitty);
+    this->add("sticky_note_quality", S_BOOL, !is_shitty);
 #else
-    this->add("sticky_note_hd", S_BOOL, false);
+    this->add("sticky_note_quality", S_BOOL, false);
 #endif
 
     this->add("fv",                 S_INT32,   1); /* settings file version */

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -16,13 +16,13 @@
 
 #define PIXELSZ 1
 
-#define TEX_WIDTH  (settings["sticky_note_quality"]->v.b ? 2048 : 1024)
-#define TEX_HEIGHT (settings["sticky_note_quality"]->v.b ? 2048 : 1024)
+#define TEX_WIDTH  (settings_quality ? 2048 : 1024)
+#define TEX_HEIGHT (settings_quality ? 2048 : 1024)
 
-#define WIDTH  (settings["sticky_note_quality"]->v.b ? 256 : 128)
-#define HEIGHT (settings["sticky_note_quality"]->v.b ? 256 : 128)
+#define WIDTH  (settings_quality ? 256 : 128)
+#define HEIGHT (settings_quality ? 256 : 128)
 
-#define FONT_SCALING_FACTOR (settings["sticky_note_quality"]->v.b ? 2.f : 1.f)
+#define FONT_SCALING_FACTOR (settings_quality ? 2.f : 1.f)
 
 //computed
 #define UV_X ((double) WIDTH / (double) TEX_WIDTH)
@@ -30,6 +30,7 @@
 #define SLOTS_PER_TEX_LINE (TEX_WIDTH / WIDTH)
 //
 
+static bool settings_quality;
 static bool slots[NUM_SLOTS];
 static bool initialized = false;
 static TTF_Font *ttf_font[NUM_SIZES];
@@ -40,9 +41,10 @@ tms_texture sticky::texture;
 void sticky::_init(void) {
     TTF_Init();
 
-    int unused;
+    settings_quality = settings["sticky_note_quality"]->v.b;
 
     for (int size_idx = 0; size_idx < NUM_SIZES; size_idx++) {
+        int unused;
         int font_size = FONT_SCALING_FACTOR * (double)(16 + 6 * size_idx);
         ttf_font[size_idx] = TTF_OpenFont(NOTE_FONT, font_size);
         TTF_SizeUTF8(ttf_font[size_idx], " ", &spacing[size_idx], &unused);
@@ -61,11 +63,22 @@ void sticky::_deinit(void) {
     for (int x=0; x<NUM_SIZES; x++) {
         TTF_CloseFont(ttf_font[x]);
     }
-
+    
     TTF_Quit();
+
+    //tms_texture_free(&sticky::texture);
+
+    initialized = false;
 }
 
 sticky::sticky() {
+    //Re-init if the settings changed
+    //XXX: this produces weird behaviour
+    // if (settings_quality != settings["sticky_note_quality"]->v.b) {
+    //     settings_quality = settings["sticky_note_quality"]->v.b;
+    //     if (initialized) _deinit();
+    // }
+
     if (!initialized) {
         _init();
     }

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -259,10 +259,10 @@ void sticky::draw_text(const char *txt) {
         }
 
         //Centering
-        // int align_y = this->properties[2].v.i8 ? HEIGHT/2 + this->currline*line_skip/2. : HEIGHT-1;
-        // int align_x = this->properties[1].v.i8 ? (WIDTH/2 - srf->w/2) * PIXELSZ : 0;
-        int align_y = HEIGHT - 1;
-        int align_x = 0;
+        int align_y = this->properties[2].v.i8 ? HEIGHT/2 + this->currline*line_skip/2. : HEIGHT-1;
+        int align_x = this->properties[1].v.i8 ? (WIDTH/2 - srf->w/2) * PIXELSZ : 0;
+        // int align_y = HEIGHT - 1;
+        // int align_x = 0;
         
         for (int y = 0; y < srf->h; y++) {
             for (int x = 0; x < srf->pitch; x++) {
@@ -293,14 +293,12 @@ void sticky::draw_text(const char *txt) {
                     int data_offset = (y * srf->pitch) + x;
 
                     unsigned char data = ((unsigned char*) srf->pixels)[data_offset];
-                    //data = -1;
                     buf[offset] = data;
                     
                     // tms_debugf(
                     //     "slot/offset/data_offset/data %d/%d/%d/%d/%x - '%s'",
                     //     this->slot, offset, data_offset, data, this->lines[text_line]
                     // );
-
                 }
             }
         }

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -25,8 +25,8 @@ tms_texture sticky::texture;
 
 #define PIXELSZ 1
 
-#define UV_X ((float)WIDTH / (float)TEX_WIDTH)
-#define UV_Y ((float)HEIGHT / (float)TEX_HEIGHT)
+#define UV_X ((double)WIDTH / (double)TEX_WIDTH)
+#define UV_Y ((double)HEIGHT / (double)TEX_HEIGHT)
 
 #define SLOTS_PER_TEX_LINE (TEX_WIDTH / WIDTH)
 
@@ -76,7 +76,7 @@ sticky::sticky() {
     }
 
     this->set_flag(ENTITY_ALLOW_CONNECTIONS,    false);
-    this->set_flag(ENTITY_DISABLE_LAYERS,       false);
+    this->set_flag(ENTITY_DISABLE_LAYERS,       true);
     this->set_flag(ENTITY_HAS_CONFIG,           true);
 
     this->dialog_id = DIALOG_STICKY;
@@ -258,11 +258,9 @@ void sticky::draw_text(const char *txt) {
             continue;
         }
 
-        //Centering
-        int align_y = this->properties[2].v.i8 ? HEIGHT/2 + this->currline*line_skip/2. : HEIGHT-1;
-        int align_x = this->properties[1].v.i8 ? (WIDTH/2 - srf->w/2) * PIXELSZ : 0;
-        // int align_y = HEIGHT - 1;
-        // int align_x = 0;
+        //Alignment/centering
+        int align_y = this->properties[2].v.i8 ? ((HEIGHT + this->currline * line_skip) / 2.) : HEIGHT-1;
+        int align_x = this->properties[1].v.i8 ? ((WIDTH - srf->w) / 2.) : 0;
         
         for (int y = 0; y < srf->h; y++) {
             for (int x = 0; x < srf->pitch; x++) {

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -313,7 +313,7 @@ void sticky::set_text(const char *txt) {
 }
 
 void sticky::update_text() {
-    for (int x=0; x<STICKY_MAX_LINES; x++) {
+    inline for (int x = 0; x < STICKY_MAX_LINES; x++) {
         this->linelen[x] = 0;
     }
     this->currline = 0;
@@ -351,7 +351,8 @@ void sticky::update(void) {
         this->M[5] = t.q.c;
         this->M[12] = t.p.x;
         this->M[13] = t.p.y;
-        this->M[14] = this->get_layer()*LAYER_DEPTH - LAYER_DEPTH/2.1f;
+        this->M[14] = LAYER_DEPTH / -2.1f;
+        //this->M[14] = this->get_layer()*LAYER_DEPTH - LAYER_DEPTH/2.1f;
 
         tmat3_copy_mat4_sub3x3(this->N, this->M);
     } else {

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -318,18 +318,17 @@ void sticky::update_text() {
     }
     this->currline = 0;
 
-    /* clear the texture */
-    int sy = HEIGHT-1;
-    int sx = 0;
+    // clear the texture
     unsigned char *buf = tms_texture_get_buffer(&sticky::texture);
-    buf += this->slot * WIDTH * HEIGHT;
-
-    for (int y=0; y<HEIGHT; y++) {
-        for (int x=0; x<WIDTH; x++) {
-            buf[((sy)-y)*WIDTH + 0+sx+x] = 0;
+    size_t ty = (this->slot / SLOTS_PER_TEX_LINE) * HEIGHT;
+    size_t tx = (this->slot % SLOTS_PER_TEX_LINE) * WIDTH;
+    for (size_t y = ty; y < (ty + HEIGHT); y++) {
+        for (size_t x = tx; x < (tx + WIDTH); x++) {
+            buf[x + y * TEX_WIDTH] = 0;
         }
     }
 
+    // inital render
     this->draw_text(this->properties[0].v.s.buf);
     tms_texture_upload(&sticky::texture);
 }

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -85,7 +85,6 @@ sticky::sticky() {
     this->menu_scale = .75f;
     this->set_mesh(mesh_factory::get_mesh(MODEL_STICKY));
     this->set_material(&m_sticky);
-    //this->set_uniform("~color", 233.f/255.f, 191.f/255.f, .2f, 1.f);
     this->set_uniform("~color", sqrtf(233.f/255.f), sqrtf(191.f/255.f), sqrtf(.2f), 1.f);
     this->body = 0;
     this->currline = 0;
@@ -284,12 +283,16 @@ void sticky::draw_text(const char *txt) {
                     ) * PIXELSZ + dest_z;
                     
                     #ifdef DEBUG
-                        tms_assertf(offset < TEX_HEIGHT * TEX_WIDTH, "out of bounds access");
+                        if (offset >= TEX_HEIGHT * TEX_WIDTH) {
+                            tms_warnf("out of bounds access");
+                            continue;
+                        }
                     #endif
 
                     //Source
                     int data_offset = (y * srf->pitch) + x;
 
+                    //Source -> Destination
                     unsigned char data = ((unsigned char*) srf->pixels)[data_offset];
                     buf[offset] = data;
                     

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -3,6 +3,7 @@
 #include "material.hh"
 #include "world.hh"
 #include "ui.hh"
+#include "settings.hh"
 
 #include "SDL_ttf.h"
 
@@ -15,23 +16,13 @@
 
 #define PIXELSZ 1
 
-#ifdef TMS_BACKEND_PC
-    #define TEX_WIDTH 2048
-    #define TEX_HEIGHT 2048
+#define TEX_WIDTH  (settings["sticky_note_hd"]->v.b ? 2048 : 1024)
+#define TEX_HEIGHT (settings["sticky_note_hd"]->v.b ? 2048 : 1024)
 
-    #define WIDTH 256
-    #define HEIGHT 256
+#define WIDTH  (settings["sticky_note_hd"]->v.b ? 256 : 128)
+#define HEIGHT (settings["sticky_note_hd"]->v.b ? 256 : 128)
 
-    #define FONT_SCALING_FACTOR 2.
-#else
-    #define TEX_WIDTH 1024
-    #define TEX_HEIGHT 1024
-
-    #define WIDTH 128
-    #define HEIGHT 128
-
-    #define FONT_SCALING_FACTOR 1.
-#endif
+#define FONT_SCALING_FACTOR (settings["sticky_note_hd"]->v.b ? 2.f : 1.f)
 
 //computed
 #define UV_X ((double) WIDTH / (double) TEX_WIDTH)

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -42,6 +42,9 @@ void sticky::_init(void) {
     TTF_Init();
 
     settings_quality = settings["sticky_note_quality"]->v.b;
+    if (tbackend_is_shitty() || settings["is_very_shitty"]->v.b) {
+        settings_quality = false;
+    }
 
     for (int size_idx = 0; size_idx < NUM_SIZES; size_idx++) {
         int unused;
@@ -50,7 +53,6 @@ void sticky::_init(void) {
         TTF_SizeUTF8(ttf_font[size_idx], " ", &spacing[size_idx], &unused);
     }
 
-    //texture = tms_texture_alloc();
     tms_texture_init(&sticky::texture);
     tms_texture_set_filtering(&sticky::texture, GL_LINEAR);
     tms_texture_alloc_buffer(&sticky::texture, TEX_WIDTH, TEX_HEIGHT, PIXELSZ);
@@ -65,8 +67,6 @@ void sticky::_deinit(void) {
     }
     
     TTF_Quit();
-
-    //tms_texture_free(&sticky::texture);
 
     initialized = false;
 }

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -257,16 +257,20 @@ void sticky::draw_text(const char *txt) {
         for (int y = 0; y < srf->h; y++) {
             for (int x = 0; x < srf->pitch; x++) {
                 for (int z = 0; z < PIXELSZ; z++) {
-                    size_t dest_y = ((align_y - line_skip * text_line) - y);
-                    size_t dest_x = align_x + x;
-                    size_t dest_z = z;
+                    int dest_y = ((align_y - line_skip * text_line) - y);
+                    int dest_x = align_x + x;
+                    
+                    //Prevent leaking to other notes
+                    if ((dest_x < 0) || (dest_x >= WIDTH)) continue;
+                    if ((dest_y < 0) || (dest_y >= HEIGHT)) continue;
 
                     //Destination
                     size_t offset = (
-                        (((this->slot / SLOTS_PER_TEX_LINE) * HEIGHT + dest_y) * TEX_WIDTH) +
-                        ((this->slot % SLOTS_PER_TEX_LINE) * WIDTH) + dest_x
-                    ) * PIXELSZ + dest_z;
+                        (((this->slot / SLOTS_PER_TEX_LINE) * HEIGHT + (size_t) dest_y) * TEX_WIDTH) +
+                        ((this->slot % SLOTS_PER_TEX_LINE) * WIDTH) + (size_t) dest_x
+                    ) * PIXELSZ + z;
                     
+                    //Prevent out-of-bounds access
                     if (offset >= TEX_HEIGHT * TEX_WIDTH) continue;
 
                     //Source

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -8,34 +8,43 @@
 
 #include <cstddef>
 
-#define NUM_SIZES 4
-
-static bool initialized = false;
-static TTF_Font *ttf_font[NUM_SIZES];
-static SDL_Surface *surface;
-static int spacing[NUM_SIZES];
-
-tms_texture sticky::texture;
-
-#define TEX_WIDTH 1024
-#define TEX_HEIGHT 1024
-#define PIXELSZ 1
-
-#define WIDTH 128
-#define HEIGHT 128
+#define NUM_SLOTS 64
 
 #define NOTE_FONT "data-shared/fonts/easyspeech.ttf"
+#define NUM_SIZES 4
 
-#define FONT_SCALING_FACTOR 1.
+#define PIXELSZ 1
 
-#define NUM_SLOTS 64
+#ifdef TMS_BACKEND_PC
+    #define TEX_WIDTH 2048
+    #define TEX_HEIGHT 2048
+
+    #define WIDTH 256
+    #define HEIGHT 256
+
+    #define FONT_SCALING_FACTOR 2.
+#else
+    #define TEX_WIDTH 1024
+    #define TEX_HEIGHT 1024
+
+    #define WIDTH 128
+    #define HEIGHT 128
+
+    #define FONT_SCALING_FACTOR 1.
+#endif
 
 //computed
 #define UV_X ((double) WIDTH / (double) TEX_WIDTH)
 #define UV_Y ((double) HEIGHT / (double) TEX_HEIGHT)
 #define SLOTS_PER_TEX_LINE (TEX_WIDTH / WIDTH)
+//
 
 static bool slots[NUM_SLOTS];
+static bool initialized = false;
+static TTF_Font *ttf_font[NUM_SIZES];
+static SDL_Surface *surface;
+static int spacing[NUM_SIZES];
+tms_texture sticky::texture;
 
 void sticky::_init(void) {
     TTF_Init();

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -17,7 +17,7 @@ static int spacing[NUM_SIZES];
 
 tms_texture sticky::texture;
 
-#define TEX_WIDTH 128
+#define TEX_WIDTH 1024
 #define TEX_HEIGHT 1024
 
 #define WIDTH 128
@@ -30,7 +30,7 @@ tms_texture sticky::texture;
 
 #define SLOTS_PER_TEX_LINE (TEX_WIDTH / WIDTH)
 
-#define NUM_SLOTS 4
+#define NUM_SLOTS 64
 
 static bool slots[NUM_SLOTS];
 
@@ -51,7 +51,7 @@ void sticky::_init(void) {
     //texture = tms_texture_alloc();
     tms_texture_init(&sticky::texture);
     tms_texture_set_filtering(&sticky::texture, GL_LINEAR);
-    tms_texture_alloc_buffer(&sticky::texture, WIDTH, HEIGHT * NUM_SLOTS, PIXELSZ);
+    tms_texture_alloc_buffer(&sticky::texture, TEX_WIDTH, TEX_HEIGHT, PIXELSZ);
     tms_texture_clear_buffer(&sticky::texture, 0);
 
     initialized = true;
@@ -284,7 +284,11 @@ void sticky::draw_text(const char *txt) {
                         (((this->slot / SLOTS_PER_TEX_LINE) * HEIGHT + dest_y) * TEX_WIDTH) +
                         ((this->slot % SLOTS_PER_TEX_LINE) * WIDTH) + dest_x
                     ) * PIXELSZ + dest_z;
-                        
+                    
+                    #ifdef DEBUG
+                        tms_assertf(offset < TEX_HEIGHT * TEX_WIDTH, "out of bounds access");
+                    #endif
+
                     //Source
                     int data_offset = (y * srf->pitch) + x;
 

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -313,7 +313,7 @@ void sticky::set_text(const char *txt) {
 }
 
 void sticky::update_text() {
-    inline for (int x = 0; x < STICKY_MAX_LINES; x++) {
+    for (int x = 0; x < STICKY_MAX_LINES; x++) {
         this->linelen[x] = 0;
     }
     this->currline = 0;

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -52,7 +52,7 @@ void sticky::_init(void) {
     int unused;
 
     for (int size_idx = 0; size_idx < NUM_SIZES; size_idx++) {
-        int font_size = 16 + 6 * size_idx;
+        int font_size = FONT_SCALING_FACTOR * (double)(16 + 6 * size_idx);
         ttf_font[size_idx] = TTF_OpenFont(NOTE_FONT, font_size);
         TTF_SizeUTF8(ttf_font[size_idx], " ", &spacing[size_idx], &unused);
     }

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -19,18 +19,21 @@ tms_texture sticky::texture;
 
 #define TEX_WIDTH 1024
 #define TEX_HEIGHT 1024
+#define PIXELSZ 1
 
 #define WIDTH 128
 #define HEIGHT 128
 
-#define PIXELSZ 1
+#define NOTE_FONT "data-shared/fonts/easyspeech.ttf"
 
-#define UV_X ((double)WIDTH / (double)TEX_WIDTH)
-#define UV_Y ((double)HEIGHT / (double)TEX_HEIGHT)
-
-#define SLOTS_PER_TEX_LINE (TEX_WIDTH / WIDTH)
+#define FONT_SCALING_FACTOR 1.
 
 #define NUM_SLOTS 64
+
+//computed
+#define UV_X ((double) WIDTH / (double) TEX_WIDTH)
+#define UV_Y ((double) HEIGHT / (double) TEX_HEIGHT)
+#define SLOTS_PER_TEX_LINE (TEX_WIDTH / WIDTH)
 
 static bool slots[NUM_SLOTS];
 
@@ -39,13 +42,10 @@ void sticky::_init(void) {
 
     int unused;
 
-    for (int x=0; x<NUM_SIZES; x++) {
-        ttf_font[x] = TTF_OpenFont("data-shared/fonts/easyspeech.ttf", 16+6*x);
-        //ttf_font[x] = TTF_OpenFont("data/fonts/quivira.ttf", 16+6*x);
-        //ttf_font[x] = TTF_OpenFont("data/fonts/gulim.ttf", 16+6*x);
-        //ttf_font[x] = TTF_OpenFont("data/fonts/DejaVuSans.ttf", 16+6*x);
-        //ttf_font[x] = TTF_OpenFont("data/fonts/Ubuntu-R.ttf", 16+6*x);
-        TTF_SizeUTF8(ttf_font[x], " ", &spacing[x], &unused);
+    for (int size_idx = 0; size_idx < NUM_SIZES; size_idx++) {
+        int font_size = FONT_SCALING_FACTOR * (double)(16 + 6 * size_idx);
+        ttf_font[size_idx] = TTF_OpenFont(NOTE_FONT, font_size);
+        TTF_SizeUTF8(ttf_font[size_idx], " ", &spacing[size_idx], &unused);
     }
 
     //texture = tms_texture_alloc();

--- a/src/src/sticky.cc
+++ b/src/src/sticky.cc
@@ -16,13 +16,13 @@
 
 #define PIXELSZ 1
 
-#define TEX_WIDTH  (settings["sticky_note_hd"]->v.b ? 2048 : 1024)
-#define TEX_HEIGHT (settings["sticky_note_hd"]->v.b ? 2048 : 1024)
+#define TEX_WIDTH  (settings["sticky_note_quality"]->v.b ? 2048 : 1024)
+#define TEX_HEIGHT (settings["sticky_note_quality"]->v.b ? 2048 : 1024)
 
-#define WIDTH  (settings["sticky_note_hd"]->v.b ? 256 : 128)
-#define HEIGHT (settings["sticky_note_hd"]->v.b ? 256 : 128)
+#define WIDTH  (settings["sticky_note_quality"]->v.b ? 256 : 128)
+#define HEIGHT (settings["sticky_note_quality"]->v.b ? 256 : 128)
 
-#define FONT_SCALING_FACTOR (settings["sticky_note_hd"]->v.b ? 2.f : 1.f)
+#define FONT_SCALING_FACTOR (settings["sticky_note_quality"]->v.b ? 2.f : 1.f)
 
 //computed
 #define UV_X ((double) WIDTH / (double) TEX_WIDTH)

--- a/src/src/ui.cc
+++ b/src/src/ui.cc
@@ -1332,6 +1332,9 @@ Java_org_libsdl_app_PrincipiaBackend_getSettings(JNIEnv *env, jclass _jcls)
                 f = env->GetFieldID(cls, "texture_quality", "I");
                 env->SetIntField(ret, f, settings["texture_quality"]->v.i);
 
+                f = env->GetFieldID(cls, "sticky_note_quality", "Z");
+                env->SetBooleanField(ret, f, settings["sticky_note_quality"]->v.b);
+
                 f = env->GetFieldID(cls, "uiscale", "F");
                 env->SetFloatField(ret, f, settings["uiscale"]->v.f);
 
@@ -1485,7 +1488,8 @@ Java_org_libsdl_app_PrincipiaBackend_setSettings(JNIEnv *env, jclass _jcls,
         jboolean muted,
         jboolean hide_tips,
         jboolean sandbox_back_dna,
-        jint display_fps
+        jint display_fps,
+        jboolean sticky_note_quality
         )
 {
     bool do_reload_graphics = false;
@@ -1502,6 +1506,8 @@ Java_org_libsdl_app_PrincipiaBackend_setSettings(JNIEnv *env, jclass _jcls,
     } else if (settings["ao_map_res"]->v.i != (int)ao_map_res) {
         do_reload_graphics = true;
     } else if (settings["texture_quality"]->v.i != (int)texture_quality) {
+        do_reload_graphics = true;
+    } else if (settings["sticky_note_quality"]->v.b != (bool)sticky_note_quality) {
         do_reload_graphics = true;
     }
 
@@ -1523,6 +1529,7 @@ Java_org_libsdl_app_PrincipiaBackend_setSettings(JNIEnv *env, jclass _jcls,
     settings["shadow_map_resy"]->v.i = (int)shadow_map_resy;
     settings["ao_map_res"]->v.i = (int)ao_map_res;
     settings["texture_quality"]->v.i = (int)texture_quality;
+    settings["sticky_note_quality"]->v.b = (bool)sticky_note_quality;
 
     if (settings["uiscale"]->set((float)uiscale)) {
         ui::message("You need to restart Principia before the UI scale change takes effect.");

--- a/src/src/ui.cc
+++ b/src/src/ui.cc
@@ -3396,6 +3396,11 @@ struct table_setting_row settings_graphic_rows[] = {
         0,
         "gamma_correct",
         setting_row_type::create_checkbox()
+    }, {
+        "Sticky note quality",
+        "Enabled: 256x256\r\nDisabled 128x128\r\nRestart required",
+        "sticky_note_quality",
+        setting_row_type::create_checkbox()
     },
 };
 

--- a/src/src/ui.cc
+++ b/src/src/ui.cc
@@ -3404,7 +3404,7 @@ struct table_setting_row settings_graphic_rows[] = {
         "gamma_correct",
         setting_row_type::create_checkbox()
     }, {
-        "Sticky note quality",
+        "Sticky note resolution",
         "Enabled: 256x256\r\nDisabled 128x128\r\nRestart required",
         "sticky_note_quality",
         setting_row_type::create_checkbox()


### PR DESCRIPTION
Shoves (up to) 64 notes into a single 1024x1024/2048x2048 texture!    
  
Everything is configurable! (Note width, height, font scale, texture width/height, slot count, non-square textures *should* be supported)  

should be good enough (tm) to merge, but please test thoroughly.
  
This also adds a new "Sticky note resolution" option (which is enabled *by default* on PC, and disabled on Android)
  
This is not a complete rewrite, and it still does some weird things under the hood...

Btw, I disabled layer switching I added in the #107, mostly just for testing, but it didn't work wery well anyway. :p   
basically just a visual change.