### PR TITLE
Experimental GTK3-based quick level browser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,11 @@ if(NOT SCREENSHOT_BUILD)
 		include_directories(
 			${GLEW_INCLUDE_DIRS}
 			${GTK3_INCLUDE_DIRS})
+
+		# Only requrired by the level browser
+		# TODO: make the gtk3 level browser optional
+		find_package(nlohmann_json 3.2.0 REQUIRED)
+		include_directories(${NLOHMANN_JSON_INCLUDE_DIRS})
 	endif()
 
 	find_package(CURL REQUIRED)

--- a/src/src/menu_main.cc
+++ b/src/src/menu_main.cc
@@ -24,10 +24,9 @@ menu_main::widget_clicked(principia_wdg *w, uint8_t button_id, int pid)
             P.add_action(ACTION_GOTO_CREATE, 1);
             break;
 
-        case BTN_BROWSE_COMMUNITY: {
-            COMMUNITY_URL("");
-            ui::open_url(url);
-        } break;
+        case BTN_BROWSE_COMMUNITY:
+            ui::open_dialog(DIALOG_HC_LEVEL_BROWSER);
+            break;
 
         case BTN_UPDATE: {
             COMMUNITY_URL("download");

--- a/src/src/ui.hh
+++ b/src/src/ui.hh
@@ -73,6 +73,11 @@
 #define DIALOG_DECORATION       161
 #define DIALOG_SFXEMITTER_2     162
 
+// Open native level browser dialog
+// ..or open community host if it's not
+//   supported by the current backend
+#define DIALOG_HC_LEVEL_BROWSER 163
+
 #define CLOSE_ALL_DIALOGS                  200
 #define CLOSE_ABSOLUTELY_ALL_DIALOGS       201
 #define CLOSE_REGISTER_DIALOG              202

--- a/src/src/ui_gtk3.hh
+++ b/src/src/ui_gtk3.hh
@@ -11612,6 +11612,7 @@ ui::open_dialog(int num, void *data/*=0*/)
             #else
                 ui::open_url(P.community_host);
             #endif
+            break;
 
         default:
             tms_warnf("Unhandled dialog ID: %d", num);

--- a/src/src/ui_gtk3.hh
+++ b/src/src/ui_gtk3.hh
@@ -1,4 +1,5 @@
 
+#include "main.hh"
 #ifdef TMS_BACKEND_PC
 
 // fuckgtk3
@@ -7,6 +8,8 @@
 
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
+
+#include "ui_gtk3_levelbrowser.hh"
 
 #ifdef USE_GTK_SOURCE_VIEW
 #include <gtksourceview/gtksource.h>
@@ -11602,6 +11605,13 @@ ui::open_dialog(int num, void *data/*=0*/)
             gdk_threads_add_timeout(40, _open_prompt_dialog, 0);
             break;
         case DIALOG_PROMPT_SETTINGS: gdk_threads_add_idle(_open_prompt_settings_dialog, 0); break;
+
+        case DIALOG_HC_LEVEL_BROWSER:
+            #ifdef GTK3_LEVEL_BROWSER_ENABLE
+                gdk_threads_add_idle(open_community_level_browser, 0);
+            #else
+                ui::open_url(P.community_host);
+            #endif
 
         default:
             tms_warnf("Unhandled dialog ID: %d", num);

--- a/src/src/ui_gtk3.hh
+++ b/src/src/ui_gtk3.hh
@@ -6280,6 +6280,10 @@ int _gtk_loop(void *p)
     //Load CSS themes
     load_gtk_css();
 
+#ifdef GTK3_LEVEL_BROWSER_ENABLE
+    init_community_level_browser();
+#endif
+
     g_object_set(
         gtk_settings_get_default(),
         "gtk-application-prefer-dark-theme", true,

--- a/src/src/ui_gtk3_levelbrowser.cc
+++ b/src/src/ui_gtk3_levelbrowser.cc
@@ -1,17 +1,94 @@
 #include "ui_gtk3_levelbrowser.hh"
+#include "tms/backend/print.h"
 
-#if !defined(GTK3_LEVEL_BROWSER_DISABLE) && defined(TMS_BACKEND_PC) && !defined(NO_UI) && !defined(TMS_BACKEND_EMSCRIPTEN)
+#ifdef GTK3_LEVEL_BROWSER_ENABLE
 
-// TODO maybe vendor?
+#include "main.hh"
+#include <curl/curl.h>
 #include <nlohmann/json.hpp>
+#include <SDL_mutex.h>
+
 using json = nlohmann::json;
 
-GtkCommunityDialog::GtkCommunityDialog() {
-
+template <typename T>
+std::unique_ptr<T> get_nullable(const nlohmann::json &j, const std::string &field_name) {
+    if (j.contains(field_name) && !j.at(field_name).is_null()) {
+        return std::make_unique<T>(j.at(field_name).get<T>());
+    }
+    return nullptr;
 }
 
-GtkCommunityDialog::~GtkCommunityDialog() {
+api::user::user(json &j) {
+    id = j["id"];
+    name = j.at("name").get<std::string>();
+    customcolor = get_nullable<std::string>(j, "customcolor");
+}
 
+api::recent_level::recent_level(json &j): u(j) {
+    id = j["id"];
+    title = j["title"].get<std::string>();
+}
+
+api::level::level(json &j): u(j) {
+    id = j["id"];
+    cat = j["cat"];
+    title = j["title"].get<std::string>();
+    description = j["description"].get<std::string>();
+    author = j["author"];
+    time = j["time"];
+    parent = get_nullable<uint32_t>(j, "parent");
+    revision = j["revision"];
+    revision_time = get_nullable<uint32_t>(j, "revision_time");
+    visibility = j["visibility"];
+    views = j["views"];
+    likes = j["likes"];
+    downloads = j["downloads"];
+    platform = j["platform"].get<std::string>();
+}
+
+// TODO move to network.cc?
+
+// TODO non-blocking request
+
+std::vector<api::recent_level> api::get_recent_levels(uint32_t offset, uint32_t limit) {
+    if (!P.curl) tms_fatalf("curl not initialized");
+    SDL_LockMutex(P.curl_mutex);
+
+    std::vector<api::recent_level> levels;
+
+    char url[256];
+    snprintf(url, 255, "https://%s/api/latest_levels?offset=%u&limit=%u", P.community_host, offset, limit);
+
+    curl_easy_setopt(P.curl, CURLOPT_URL, url);
+
+    std::string response;
+    curl_easy_setopt(P.curl, CURLOPT_WRITEDATA, &response);
+
+    // TODO handle error
+    CURLcode res = curl_easy_perform(P.curl);
+    if (res != CURLE_OK) tms_fatalf("[fuck] curl error");
+
+    // TODO handle error
+    long http_code = 0;
+    curl_easy_getinfo(P.curl, CURLINFO_RESPONSE_CODE, &http_code);
+    if (http_code != 200) tms_fatalf("[fuck] HTTP error %ld", http_code);
+
+    SDL_UnlockMutex(P.curl_mutex);
+
+    json data = json::parse(response);
+
+    // Data contains an array of api::recent_level
+
+    for (const auto& item : data) {
+        levels.emplace_back(item);
+    }
+
+    return levels;
+}
+
+// TODO implement this
+api::level api::get_level(uint32_t id) {
+    tms_fatalf("not implemented"); exit(1);
 }
 
 #endif

--- a/src/src/ui_gtk3_levelbrowser.cc
+++ b/src/src/ui_gtk3_levelbrowser.cc
@@ -1,0 +1,18 @@
+#include "ui_gtk3_levelbrowser.hh"
+
+#if !defined(GTK3_LEVEL_BROWSER_DISABLE) && defined(TMS_BACKEND_PC) && !defined(NO_UI) && !defined(TMS_BACKEND_EMSCRIPTEN)
+
+// TODO maybe vendor?
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+GtkCommunityDialog::GtkCommunityDialog() {
+
+}
+
+GtkCommunityDialog::~GtkCommunityDialog() {
+
+}
+
+#endif
+

--- a/src/src/ui_gtk3_levelbrowser.cc
+++ b/src/src/ui_gtk3_levelbrowser.cc
@@ -1,99 +1,203 @@
 #include "ui_gtk3_levelbrowser.hh"
-#include "tms/backend/print.h"
+#include <string>
+
 
 #ifdef GTK3_LEVEL_BROWSER_ENABLE
 
 #include "main.hh"
+#include "tms/backend/print.h"
+
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 #include <SDL_mutex.h>
 #include <glib.h>
+#include <gtk/gtk.h>
 
-using json = nlohmann::json;
+namespace api {
+    using json = nlohmann::json;
 
-template <typename T>
-std::unique_ptr<T> get_nullable(const nlohmann::json &j, const std::string &field_name) {
-    if (j.contains(field_name) && !j.at(field_name).is_null()) {
-        return std::make_unique<T>(j.at(field_name).get<T>());
-    }
-    return nullptr;
-}
-
-api::user::user(const json &j) {
-    id = j["id"];
-    name = j.at("name").get<std::string>();
-    customcolor = get_nullable<std::string>(j, "customcolor");
-}
-
-api::recent_level::recent_level(const json &j): u(j) {
-    id = j["id"];
-    title = j["title"].get<std::string>();
-}
-
-api::level::level(const json &j): u(j) {
-    id = j["id"];
-    cat = j["cat"];
-    title = j["title"].get<std::string>();
-    description = j["description"].get<std::string>();
-    author = j["author"];
-    time = j["time"];
-    parent = get_nullable<uint32_t>(j, "parent");
-    revision = j["revision"];
-    revision_time = get_nullable<uint32_t>(j, "revision_time");
-    visibility = j["visibility"];
-    views = j["views"];
-    likes = j["likes"];
-    downloads = j["downloads"];
-    platform = j["platform"].get<std::string>();
-}
-
-// TODO move to network.cc?
-
-// TODO non-blocking request
-
-std::vector<api::recent_level> api::get_recent_levels(uint32_t offset, uint32_t limit) {
-    if (!P.curl) tms_fatalf("curl not initialized");
-    SDL_LockMutex(P.curl_mutex);
-
-    std::vector<api::recent_level> levels;
-
-    char url[256];
-    snprintf(url, 255, "https://%s/api/latest_levels?offset=%u&limit=%u", P.community_host, offset, limit);
-
-    curl_easy_setopt(P.curl, CURLOPT_URL, url);
-
-    std::string response;
-    curl_easy_setopt(P.curl, CURLOPT_WRITEDATA, &response);
-
-    // TODO handle error
-    CURLcode res = curl_easy_perform(P.curl);
-    if (res != CURLE_OK) tms_fatalf("[fuck] curl error");
-
-    // TODO handle error
-    long http_code = 0;
-    curl_easy_getinfo(P.curl, CURLINFO_RESPONSE_CODE, &http_code);
-    if (http_code != 200) tms_fatalf("[fuck] HTTP error %ld", http_code);
-
-    SDL_UnlockMutex(P.curl_mutex);
-
-    json data = json::parse(response);
-
-    // Data contains an array of api::recent_level
-
-    for (const auto& item : data) {
-        levels.emplace_back(item);
+    template <typename T>
+    std::unique_ptr<T> get_nullable(const nlohmann::json &j, const std::string &field_name) {
+        if (j.contains(field_name) && !j.at(field_name).is_null()) {
+            return std::make_unique<T>(j.at(field_name).get<T>());
+        }
+        return nullptr;
     }
 
-    return levels;
+    user::user(const json &j) {
+        id = j["u_id"];
+        name = j.at("u_name").get<std::string>();
+        customcolor = get_nullable<std::string>(j, "u_customcolor");
+    }
+
+    recent_level::recent_level(const json &j): u(j) {
+        id = j["id"];
+        title = j["title"].get<std::string>();
+    }
+
+    // recent_level::recent_level(const struct level l): u(l.u) {
+    //     id = l.id;
+    //     title = l.title;
+    // }
+
+    level::level(const json &j): u(j) {
+        id = j["id"];
+        cat = j["cat"];
+        title = j["title"].get<std::string>();
+        description = j["description"].get<std::string>();
+        author = j["author"];
+        time = j["time"];
+        parent = get_nullable<uint32_t>(j, "parent");
+        revision = j["revision"];
+        revision_time = get_nullable<uint32_t>(j, "revision_time");
+        visibility = j["visibility"];
+        views = j["views"];
+        likes = j["likes"];
+        downloads = j["downloads"];
+        platform = j["platform"].get<std::string>();
+    }
+
+    // TODO move to network.cc?
+
+    // TODO non-blocking request
+
+    static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
+        ((std::string*)userp)->append((char*)contents, size * nmemb);
+        return size * nmemb;
+    }
+
+    static std::vector<struct recent_level> get_recent_levels(uint32_t offset, uint32_t limit) {
+        if (!P.curl) tms_fatalf("curl not initialized");
+        SDL_LockMutex(P.curl_mutex);
+
+        std::vector<api::recent_level> levels;
+
+        char url[256];
+        snprintf(url, 255, "https://%s/api/latest_levels?offset=%u&limit=%u", P.community_host, offset, limit);
+
+        curl_easy_setopt(P.curl, CURLOPT_URL, url);
+
+        std::string response;
+        curl_easy_setopt(P.curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+        curl_easy_setopt(P.curl, CURLOPT_WRITEDATA, &response);
+
+        // TODO handle error
+        CURLcode res = curl_easy_perform(P.curl);
+        if (res != CURLE_OK) tms_fatalf("[fuck] curl error");
+
+        // TODO handle error
+        long http_code = 0;
+        curl_easy_getinfo(P.curl, CURLINFO_RESPONSE_CODE, &http_code);
+        if (http_code != 200) tms_fatalf("[fuck] HTTP error %ld", http_code);
+
+        SDL_UnlockMutex(P.curl_mutex);
+
+        json data = json::parse(response);
+
+        // Data contains an array of api::recent_level
+
+        for (const auto& item : data) {
+            levels.emplace_back(item);
+        }
+
+        return levels;
+    }
+
+    // TODO implement this
+    static struct level get_level(uint32_t id) {
+        tms_fatalf("not implemented"); exit(1);
+    }
 }
 
-// TODO implement this
-api::level api::get_level(uint32_t id) {
-    tms_fatalf("not implemented"); exit(1);
+namespace gtk_community {
+    // Callback function for clicking on the level title
+    static void on_level_clicked(GtkWidget *widget, gpointer data) {
+        g_print("Level clicked: %s\n", (char *)data);
+    }
+
+    // Callback function for clicking on the username
+    static void on_username_clicked(GtkWidget *widget, gpointer data) {
+        g_print("Username clicked: %s\n", (char *)data);
+    }
+
+    static GtkWidget* create_level_tile(const api::recent_level &level) {
+        // TODO this is placeholder
+        const char *title = level.title.c_str();
+        const char *username = level.u.name.c_str();
+        // Create a box to hold the tile elements vertically
+        GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+
+        // Placeholder for the level image (just a blank box for now)
+        GtkWidget *image = gtk_drawing_area_new();
+        gtk_widget_set_size_request(image, 100, 100); // Placeholder size
+        gtk_widget_set_name(image, "level-image");
+
+        // Level title (clickable button)
+        GtkWidget *level_button = gtk_button_new_with_label(title);
+        g_signal_connect(level_button, "clicked", G_CALLBACK(on_level_clicked), (gpointer)title);
+
+        // Username (clickable label)
+        // TODO set user color
+        GtkWidget *username_button = gtk_button_new_with_label(username);
+        gpointer user_id = (gpointer)(size_t)level.u.id;
+        g_signal_connect(username_button, "clicked", G_CALLBACK(on_username_clicked), (gpointer)user_id);
+
+        // Pack elements into the box
+        gtk_box_pack_start(GTK_BOX(box), image, FALSE, FALSE, 0);
+        gtk_box_pack_start(GTK_BOX(box), level_button, FALSE, FALSE, 0);
+        gtk_box_pack_start(GTK_BOX(box), username_button, FALSE, FALSE, 0);
+
+        return box;
+    }
+
+    static GtkWidget* create_dialog(const std::vector<api::recent_level> &levels) {
+        GtkWidget *dialog = gtk_dialog_new_with_buttons(
+            "Community Levels",
+            NULL,
+            (GtkDialogFlags)(GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL),
+            ("_Close"),
+            GTK_RESPONSE_CLOSE,
+            NULL
+        );
+        g_signal_connect(dialog, "response", G_CALLBACK(gtk_widget_destroy), NULL);
+
+        // Get the content area of the dialog
+        GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
+
+        // Create a grid to hold the level tiles
+        GtkWidget *grid = gtk_grid_new();
+        gtk_grid_set_row_spacing(GTK_GRID(grid), 10);
+        gtk_grid_set_column_spacing(GTK_GRID(grid), 10);
+        gtk_container_add(GTK_CONTAINER(content_area), grid);
+
+        // Add level tiles to the grid
+        int num_levels = 6;
+        int rows = 2;  // 2 rows for now
+        int cols = 3;  // 3 columns for now
+
+        for (int i = 0; i < num_levels; i++) {
+            GtkWidget *level_tile = create_level_tile(levels[i]);
+
+            // Attach each tile in the grid
+            int row = i / cols;
+            int col = i % cols;
+            gtk_grid_attach(GTK_GRID(grid), level_tile, col, row, 1, 1);
+        }
+
+        return dialog;
+    }
 }
 
 gboolean open_community_level_browser(gpointer _) {
     tms_infof("====== Open level browser ======");
+
+    tms_infof("Fetching recent levels...");
+    std::vector<api::recent_level> levels = api::get_recent_levels(0, 6);
+
+    tms_infof("Creating dialog...");
+    GtkWidget *dialog = gtk_community::create_dialog(levels);
+    gtk_widget_show_all(dialog);
+
     return false;
 }
 

--- a/src/src/ui_gtk3_levelbrowser.cc
+++ b/src/src/ui_gtk3_levelbrowser.cc
@@ -7,6 +7,7 @@
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 #include <SDL_mutex.h>
+#include <glib.h>
 
 using json = nlohmann::json;
 
@@ -18,18 +19,18 @@ std::unique_ptr<T> get_nullable(const nlohmann::json &j, const std::string &fiel
     return nullptr;
 }
 
-api::user::user(json &j) {
+api::user::user(const json &j) {
     id = j["id"];
     name = j.at("name").get<std::string>();
     customcolor = get_nullable<std::string>(j, "customcolor");
 }
 
-api::recent_level::recent_level(json &j): u(j) {
+api::recent_level::recent_level(const json &j): u(j) {
     id = j["id"];
     title = j["title"].get<std::string>();
 }
 
-api::level::level(json &j): u(j) {
+api::level::level(const json &j): u(j) {
     id = j["id"];
     cat = j["cat"];
     title = j["title"].get<std::string>();
@@ -91,8 +92,9 @@ api::level api::get_level(uint32_t id) {
     tms_fatalf("not implemented"); exit(1);
 }
 
-void open_community_level_browser() {
+gboolean open_community_level_browser(gpointer _) {
     tms_infof("====== Open level browser ======");
+    return false;
 }
 
 #endif

--- a/src/src/ui_gtk3_levelbrowser.cc
+++ b/src/src/ui_gtk3_levelbrowser.cc
@@ -91,5 +91,9 @@ api::level api::get_level(uint32_t id) {
     tms_fatalf("not implemented"); exit(1);
 }
 
+void open_community_level_browser() {
+    tms_infof("====== Open level browser ======");
+}
+
 #endif
 

--- a/src/src/ui_gtk3_levelbrowser.hh
+++ b/src/src/ui_gtk3_levelbrowser.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vector>
 #if !defined(GTK3_LEVEL_BROWSER_DISABLE) && defined(TMS_BACKEND_PC) && !defined(TMS_BACKEND_EMSCRIPTEN) && !defined(NO_UI) && defined(BUILD_CURL)
     #define GTK3_LEVEL_BROWSER_ENABLE
 #endif
@@ -11,6 +12,7 @@
 #include <cstdint>
 #include <nlohmann/json.hpp>
 #include <glib.h>
+#include <gtk/gtk.h>
 
 using json = nlohmann::json;
 
@@ -23,6 +25,7 @@ namespace api {
         std::unique_ptr<std::string> customcolor; // TODO store as u32 instead
 
         user(const json &j);
+        // user(uint32_t id, std::string name);
     };
 
     struct recent_level {
@@ -31,6 +34,8 @@ namespace api {
         struct user u;
 
         recent_level(const json &j);
+        // recent_level(uint32_t id, const std::string &title, const struct user &u);
+        // recent_level(const struct level &l);
     };
 
     struct level {
@@ -53,9 +58,17 @@ namespace api {
         level(const json &j);
     };
 
-    std::vector<recent_level> get_recent_levels(uint32_t offset, uint32_t limit);
-    level get_level(uint32_t id);
+    static std::vector<recent_level> get_recent_levels(uint32_t offset, uint32_t limit);
+    static level get_level(uint32_t id);
 };
+
+namespace gtk_community {
+    static void on_level_clicked(GtkWidget *widget, gpointer data);
+    static void on_username_clicked(GtkWidget *widget, gpointer data);
+    // Creates a single level tile (image, title, and username)
+    static GtkWidget *create_level_tile(const api::recent_level &level);
+    static GtkWidget *create_dialog(const std::vector<api::recent_level> &levels);
+}
 
 // DO NOT USE THIS FUNCTION DIRECTLY
 // Use ui::open_dialog(DIALOG_HC_LEVEL_BROWSER) instead!

--- a/src/src/ui_gtk3_levelbrowser.hh
+++ b/src/src/ui_gtk3_levelbrowser.hh
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <unordered_map>
+#if !defined(GTK3_LEVEL_BROWSER_DISABLE) && defined(TMS_BACKEND_PC) && !defined(NO_UI) && !defined(TMS_BACKEND_EMSCRIPTEN)
+
+#include <string>
+#include <cstdint>
+// #include "optional.hh"
+
+#define COMMUNITY_LEVELS_PER_PAGE 16
+
+class CommunityUser {
+    uint32_t id;
+    std::string name;
+    std::string customcolor; // TODO store as u32 instead
+};
+
+class CommunityRecentLevel {
+    uint32_t id;
+    std::string title;
+    CommunityUser u;
+};
+
+// {"id":1,"cat":1,"title":"not so smiley man","description":"finally\r\n\r\nnot so smiley man","author":1,"time":1608998715,"parent":null,"revision":1,"revision_time":null,"likes":21,"visibility":0,"views":433,"downloads":484,"platform":"Linux","u_id":1,"u_name":"ROllerozxa","u_customcolor":"31C03B"}
+
+class CommunityLevel {
+    uint32_t id;
+
+    uint8_t cat;
+
+    std::string title;
+    std::string description;
+
+    uint32_t author;
+
+    uint32_t time;
+    uint32_t parent;
+
+    uint32_t revision;
+    uint32_t revision_time;
+
+    uint8_t visibility;
+
+    uint32_t views;
+    uint32_t likes;
+    uint32_t downloads;
+
+    std::string platform;
+
+    CommunityUser u;
+};
+
+class GtkCommunityState {
+    uint16_t cur_page;
+    // std::unordered_map<uint32_t, uint8_t*> cache_thumbnails;
+    // std::unordered_map<uint16_t, uint8_t*> cache_pages;
+};
+
+class GtkCommunityDialog {
+    GtkCommunityDialog();
+    ~GtkCommunityDialog();
+};
+
+#endif

--- a/src/src/ui_gtk3_levelbrowser.hh
+++ b/src/src/ui_gtk3_levelbrowser.hh
@@ -56,6 +56,12 @@ namespace api {
     level get_level(uint32_t id);
 };
 
+// DO NOT USE THIS FUNCTION DIRECTLY
+// Use ui::open_dialog(DIALOG_HC_LEVEL_BROWSER) instead!
+//
+// (If calling from ui::open_dialog, make sure to wrap it in gdk_threads_add_idle!)
+void open_community_level_browser();
+
 // class gtk_community_state {
 //     uint16_t cur_page;
 //     // std::unordered_map<uint32_t, uint8_t*> cache_thumbnails;

--- a/src/src/ui_gtk3_levelbrowser.hh
+++ b/src/src/ui_gtk3_levelbrowser.hh
@@ -64,9 +64,12 @@ namespace api {
 };
 
 namespace gtk_community {
+    static GtkWidget *global_dialog;
+
     static void on_level_clicked(GtkWidget *widget, gpointer data);
     static void on_username_clicked(GtkWidget *widget, gpointer data);
-    // Creates a single level tile (image, title, and username)
+    static void on_search_activate(GtkWidget *widget, gpointer data);
+
     static GtkWidget *create_level_tile(const api::recent_level &level);
     static GtkWidget *create_level_grid(const std::vector<api::recent_level> &levels);
     static GtkWidget *create_top_shelf_content();

--- a/src/src/ui_gtk3_levelbrowser.hh
+++ b/src/src/ui_gtk3_levelbrowser.hh
@@ -60,6 +60,7 @@ namespace api {
 
     static std::vector<recent_level> get_recent_levels(uint32_t offset, uint32_t limit);
     static level get_level(uint32_t id);
+    static std::vector<uint8_t> get_level_thumbnail(uint32_t id, bool use_global_curl = true);
 };
 
 namespace gtk_community {
@@ -67,6 +68,9 @@ namespace gtk_community {
     static void on_username_clicked(GtkWidget *widget, gpointer data);
     // Creates a single level tile (image, title, and username)
     static GtkWidget *create_level_tile(const api::recent_level &level);
+    static GtkWidget *create_level_grid(const std::vector<api::recent_level> &levels);
+    static GtkWidget *create_top_shelf_content();
+    static GtkWidget *create_shelf(std::string name, GtkWidget *content);
     static GtkWidget *create_dialog(const std::vector<api::recent_level> &levels);
 }
 
@@ -75,6 +79,9 @@ namespace gtk_community {
 //
 // (If calling from ui::open_dialog, make sure to wrap it in gdk_threads_add_idle!)
 gboolean open_community_level_browser(gpointer _);
+
+// Call in ui::init() after gtk_init()
+void init_community_level_browser();
 
 // class gtk_community_state {
 //     uint16_t cur_page;

--- a/src/src/ui_gtk3_levelbrowser.hh
+++ b/src/src/ui_gtk3_levelbrowser.hh
@@ -10,6 +10,7 @@
 #include <string>
 #include <cstdint>
 #include <nlohmann/json.hpp>
+#include <glib.h>
 
 using json = nlohmann::json;
 
@@ -60,7 +61,7 @@ namespace api {
 // Use ui::open_dialog(DIALOG_HC_LEVEL_BROWSER) instead!
 //
 // (If calling from ui::open_dialog, make sure to wrap it in gdk_threads_add_idle!)
-void open_community_level_browser();
+gboolean open_community_level_browser(gpointer _);
 
 // class gtk_community_state {
 //     uint16_t cur_page;

--- a/src/src/ui_gtk3_levelbrowser.hh
+++ b/src/src/ui_gtk3_levelbrowser.hh
@@ -1,64 +1,70 @@
 #pragma once
 
-#include <unordered_map>
-#if !defined(GTK3_LEVEL_BROWSER_DISABLE) && defined(TMS_BACKEND_PC) && !defined(NO_UI) && !defined(TMS_BACKEND_EMSCRIPTEN)
+#if !defined(GTK3_LEVEL_BROWSER_DISABLE) && defined(TMS_BACKEND_PC) && !defined(TMS_BACKEND_EMSCRIPTEN) && !defined(NO_UI) && defined(BUILD_CURL)
+    #define GTK3_LEVEL_BROWSER_ENABLE
+#endif
 
+#ifdef GTK3_LEVEL_BROWSER_ENABLE
+
+#include <memory>
 #include <string>
 #include <cstdint>
-// #include "optional.hh"
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
 
 #define COMMUNITY_LEVELS_PER_PAGE 16
 
-class CommunityUser {
-    uint32_t id;
-    std::string name;
-    std::string customcolor; // TODO store as u32 instead
+namespace api {
+    struct user {
+        uint32_t id;
+        std::string name;
+        std::unique_ptr<std::string> customcolor; // TODO store as u32 instead
+
+        user(json &j);
+    };
+
+    struct recent_level {
+        uint32_t id;
+        std::string title;
+        struct user u;
+
+        recent_level(json &j);
+    };
+
+    struct level {
+        uint32_t id;
+        uint8_t cat;
+        std::string title;
+        std::string description;
+        uint32_t author;
+        uint32_t time;
+        std::unique_ptr<uint32_t> parent;
+        uint32_t revision;
+        std::unique_ptr<uint32_t> revision_time;
+        uint32_t likes;
+        uint8_t visibility;
+        uint32_t views;
+        uint32_t downloads;
+        std::string platform;
+        struct user u;
+
+        level(json &j);
+    };
+
+    std::vector<recent_level> get_recent_levels(uint32_t offset, uint32_t limit);
+    level get_level(uint32_t id);
 };
 
-class CommunityRecentLevel {
-    uint32_t id;
-    std::string title;
-    CommunityUser u;
-};
+// class gtk_community_state {
+//     uint16_t cur_page;
+//     // std::unordered_map<uint32_t, uint8_t*> cache_thumbnails;
+//     // std::unordered_map<uint16_t, uint8_t*> cache_pages;
+// };
 
-// {"id":1,"cat":1,"title":"not so smiley man","description":"finally\r\n\r\nnot so smiley man","author":1,"time":1608998715,"parent":null,"revision":1,"revision_time":null,"likes":21,"visibility":0,"views":433,"downloads":484,"platform":"Linux","u_id":1,"u_name":"ROllerozxa","u_customcolor":"31C03B"}
-
-class CommunityLevel {
-    uint32_t id;
-
-    uint8_t cat;
-
-    std::string title;
-    std::string description;
-
-    uint32_t author;
-
-    uint32_t time;
-    uint32_t parent;
-
-    uint32_t revision;
-    uint32_t revision_time;
-
-    uint8_t visibility;
-
-    uint32_t views;
-    uint32_t likes;
-    uint32_t downloads;
-
-    std::string platform;
-
-    CommunityUser u;
-};
-
-class GtkCommunityState {
-    uint16_t cur_page;
-    // std::unordered_map<uint32_t, uint8_t*> cache_thumbnails;
-    // std::unordered_map<uint16_t, uint8_t*> cache_pages;
-};
-
-class GtkCommunityDialog {
-    GtkCommunityDialog();
-    ~GtkCommunityDialog();
-};
+// class gtk_community_dialog {
+//     gtk_community_dialog();
+//     ~gtk_community_dialog();
+// };
 
 #endif

--- a/src/src/ui_gtk3_levelbrowser.hh
+++ b/src/src/ui_gtk3_levelbrowser.hh
@@ -21,7 +21,7 @@ namespace api {
         std::string name;
         std::unique_ptr<std::string> customcolor; // TODO store as u32 instead
 
-        user(json &j);
+        user(const json &j);
     };
 
     struct recent_level {
@@ -29,7 +29,7 @@ namespace api {
         std::string title;
         struct user u;
 
-        recent_level(json &j);
+        recent_level(const json &j);
     };
 
     struct level {
@@ -49,7 +49,7 @@ namespace api {
         std::string platform;
         struct user u;
 
-        level(json &j);
+        level(const json &j);
     };
 
     std::vector<recent_level> get_recent_levels(uint32_t offset, uint32_t limit);


### PR DESCRIPTION
Adds an experimental/proof-of-concept in-game level browser for the GTK3 backend

Currently supports:
- Recent levels (no pagination yet)
  - Asynchronous thumbnail loader
- Searching levels (currently just opens search on principia-web.se)
  - Opening levels by id (enter id directly like `123` or `id:123` into the search bar)

![Screenshot_20241015_103328](https://github.com/user-attachments/assets/7137ae2e-8f26-424e-a7cd-73973423528b)


TODO:
- pagination
- in-game search (requires changes to the api)
- top rated levels
- level details screen
  - requires changes to the api for extra functionality like comments