### PR TITLE
make Windows installer high DPI aware.

### DIFF
--- a/packaging/principia_install.nsi
+++ b/packaging/principia_install.nsi
@@ -1,4 +1,6 @@
 SetCompressor lzma
+XPStyle on
+ManifestDPIAware true
 
 !include "MUI2.nsh"
 


### PR DESCRIPTION
makes the installer on Windows noticeably more clear and sharp for those with DPI scaling.
also flips on `XPStyle` to ensure newer styled UI controls are used.

before:
<img width="747" height="581" alt="principia installer before DPI" src="https://github.com/user-attachments/assets/dbd0390e-0c20-43d0-82ba-ac817129eaf2" />

after:
<img width="747" height="565" alt="principia installer after DPI" src="https://github.com/user-attachments/assets/c3124ddf-3441-4a1a-b752-6b680f0c577e" />
