### PR TITLE
Guard external URL launch in the in-game WebView

### DIFF
--- a/android/principia/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android/principia/src/main/java/org/libsdl/app/SDLActivity.java
@@ -64,6 +64,7 @@ import android.app.Dialog;
 import android.app.UiModeManager;
 import android.content.ClipboardManager;
 import android.content.ClipData;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -2096,7 +2097,11 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                     Log.v(TAG, "unhandled url " + url);
                     Log.v(TAG, "host: '" + uri.getHost()+"'");
                     Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-                    SDLActivity.mSingleton.startActivity(intent);
+                    try {
+                        SDLActivity.mSingleton.startActivity(intent);
+                    } catch (ActivityNotFoundException e) {
+                        Log.v(TAG, "No app found to open url: " + url);
+                    }
                     SDLActivity.wv_dialog.dismiss();
                 }
 


### PR DESCRIPTION
### What

In `SDLActivity`, the WebView client routes external links (anything that is not a `principia:` link or a community-host page) to an external app with a raw `startActivity(new Intent(Intent.ACTION_VIEW, uri))`. When no installed app can open the URI the call throws `ActivityNotFoundException` and the activity crashes. The dialog is also left open in that case.

This wraps the launch in a try/catch so an unresolvable link is logged and the WebView dialog still closes. Links that resolve behave exactly as before.

### Change

```diff
                     Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-                    SDLActivity.mSingleton.startActivity(intent);
+                    try {
+                        SDLActivity.mSingleton.startActivity(intent);
+                    } catch (ActivityNotFoundException e) {
+                        Log.v(TAG, "No app found to open url: " + url);
+                    }
                     SDLActivity.wv_dialog.dismiss();
```

Closes #214
